### PR TITLE
Optimize `as.promise()` methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nanonext
 Type: Package
 Title: NNG (Nanomsg Next Gen) Lightweight Messaging Library
-Version: 1.2.1.9008
+Version: 1.2.1.9009
 Description: R binding for NNG (Nanomsg Next Gen), a successor to ZeroMQ. NNG is
     a socket library implementing 'Scalability Protocols', a reliable,
     high-performance standard for common communications patterns including

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# nanonext 1.2.1.9008 (development)
+# nanonext 1.2.1.9009 (development)
 
 #### New Features
 
@@ -7,6 +7,7 @@
 #### Updates
 
 * Removes deprecated and defunct `next_config()`.
+* Performance enhancements for `promises::as.promise()` methods.
 
 # nanonext 1.2.1
 

--- a/R/aio.R
+++ b/R/aio.R
@@ -372,7 +372,7 @@ as.promise.recvAio <- function(x) {
       promise <- promises::then(
         promises::promise(
           function(resolve, reject)
-            context <- .promise(x, environment())
+            .promise(x, environment())
         ),
         onFulfilled = function(value)
           if (is_error_value(value)) stop(nng_error(value)) else value
@@ -407,7 +407,7 @@ is.promising.recvAio <- function(x) TRUE
 #' @details If successful, both \sQuote{x} and \sQuote{ctx} are preserved and
 #'     accessible from the promise callback.
 #'
-#' @return The object \sQuote{x}.
+#' @return NULL.
 #'
 #' @noRd
 #' @export

--- a/R/ncurl.R
+++ b/R/ncurl.R
@@ -247,7 +247,7 @@ as.promise.ncurlAio <- function(x) {
       promise <- promises::then(
         promises::promise(
           function(resolve, reject)
-            context <- .promise(x, environment())
+            .promise(x, environment())
         ),
         onFulfilled = function(value)
           if (value != 200L)

--- a/src/core.c
+++ b/src/core.c
@@ -625,13 +625,11 @@ inline void nano_ReleaseObject(SEXP x) {
 
 void raio_invoke_cb(void *arg) {
 
-  SEXP call, context, data, node = (SEXP) arg, ctx = TAG(node);
-  context = Rf_findVarInFrame(ctx, nano_ContextSymbol);
-  PROTECT(context);
-  data = rnng_aio_get_msg(context);
+  SEXP call, data, node = (SEXP) arg, x = TAG(node);
+  data = rnng_aio_get_msg(x);
   PROTECT(call = Rf_lcons(nano_ResolveSymbol, Rf_cons(data, R_NilValue)));
-  Rf_eval(call, ctx);
-  UNPROTECT(2);
+  Rf_eval(call, ENCLOS(x));
+  UNPROTECT(1);
   // unreliable to release linked list node from later cb, just free the payload
   SET_TAG(node, R_NilValue);
 }

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -93,6 +93,7 @@ typedef struct nano_handle_s {
 #define NANO_PROT(x) CDR(x)
 #define NANO_SET_TAG(x, v) SET_TAG(x, v)
 #define NANO_SET_PROT(x, v) SETCDR(x, v)
+#define NANO_SET_ENCLOS(x, v) SETCDR(x, v)
 #define NANO_SET_FORMALS(x, v) SETCAR(x, v)
 #define NANO_SET_BODY(x, v) SETCDR(x, v)
 #define NANO_SET_CLOENV(x, v) SET_TAG(x, v)

--- a/src/ncurl.c
+++ b/src/ncurl.c
@@ -80,13 +80,11 @@ static nano_buf nano_char_buf(const SEXP data) {
 
 static void haio_invoke_cb(void *arg) {
 
-  SEXP call, context, status, node = (SEXP) arg, ctx = TAG(node);
-  context = Rf_findVarInFrame(ctx, nano_ContextSymbol);
-  PROTECT(context);
-  status = rnng_aio_http_status(context);
+  SEXP call, status, node = (SEXP) arg, x = TAG(node);
+  status = rnng_aio_http_status(x);
   PROTECT(call = Rf_lcons(nano_ResolveSymbol, Rf_cons(status, R_NilValue)));
-  Rf_eval(call, ctx);
-  UNPROTECT(2);
+  Rf_eval(call, ENCLOS(x));
+  UNPROTECT(1);
   // unreliable to release linked list node from later cb, just free the payload
   SET_TAG(node, R_NilValue);
 

--- a/src/sync.c
+++ b/src/sync.c
@@ -502,7 +502,7 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
 SEXP rnng_create_promise(SEXP x, SEXP ctx) {
 
   if (TYPEOF(x) != ENVSXP)
-    return x;
+    return R_NilValue;
 
   SEXP aio = Rf_findVarInFrame(x, nano_AioSymbol);
   if (NANO_TAG(aio) != nano_AioSymbol)

--- a/src/sync.c
+++ b/src/sync.c
@@ -506,7 +506,7 @@ SEXP rnng_create_promise(SEXP x, SEXP ctx) {
 
   SEXP aio = Rf_findVarInFrame(x, nano_AioSymbol);
   if (NANO_TAG(aio) != nano_AioSymbol)
-    return x;
+    return R_NilValue;
 
   nano_aio *raio = (nano_aio *) NANO_PTR(aio);
 
@@ -527,14 +527,15 @@ SEXP rnng_create_promise(SEXP x, SEXP ctx) {
   case IOV_RECVAIO:
   case IOV_RECVAIOS:
   case HTTP_AIO:
-    raio->cb = nano_PreserveObject(ctx);
+    NANO_SET_ENCLOS(x, ctx);
+    raio->cb = nano_PreserveObject(x);
     break;
   case SENDAIO:
   case IOV_SENDAIO:
     break;
   }
 
-  return x;
+  return R_NilValue;
 
 }
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -211,6 +211,7 @@ nanotestp(p <- tryCatch(collect_pipe(r), error = function(e) NULL))
 if (!is.null(p)) nanotest(is_nano(p))
 nanotest(.mark())
 nanotestaio(r <- send_aio(if (is_nano(p)) p else rep, "", timeout = 500))
+if (later) nanotestn(.promise(r, new.env()))
 nanotesterr(collect_pipe(r), "valid")
 nanotest(req$recv(mode = 8L, block = 500)[4L] == 1L)
 nanotest(!.mark(FALSE))
@@ -570,6 +571,8 @@ nanotesterr(collect_aio_(list("a")), "object is not an Aio or list of Aios")
 nanotesterr(collect_aio(list(fakesock)), "object is not an Aio or list of Aios")
 nanotestn(stop_aio("a"))
 nanotestn(stop_aio(list("a")))
+nanotestn(.promise(NULL, new.env()))
+nanotestn(.promise(new.env(), new.env()))
 
 pem <- "-----BEGIN CERTIFICATE----- -----END CERTIFICATE-----"
 test_tls <- function(pem) {


### PR DESCRIPTION
Completes what #46 attempted to do.

Simplifies callback to avoid unnecessary allocations and stack protections.

Eliminates the need for an assignment call in `as.promise()` setter.