### PR TITLE
Enhance listener and dialer efficiency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nanonext
 Type: Package
 Title: NNG (Nanomsg Next Gen) Lightweight Messaging Library
-Version: 1.2.1.9024
+Version: 1.2.1.9025
 Description: R binding for NNG (Nanomsg Next Gen), a successor to ZeroMQ. NNG is
     a socket library implementing 'Scalability Protocols', a reliable,
     high-performance standard for common communications patterns including

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# nanonext 1.2.1.9024 (development)
+# nanonext 1.2.1.9025 (development)
 
 #### New Features
 
@@ -10,7 +10,7 @@
 * Warning messages for unserialization or conversion failures of received data are now suppressable.
 * Upgrades `reply()` to always return even when there is an evaluation error. This allows it to be used safely in a loop without exiting early, for example.
 * Removes deprecated and defunct `next_config()`.
-* Performance enhancements for `promises::as.promise()` methods.
+* Internal performance enhancements.
 * Updates bundled 'libnng' v1.8.0 with latest patches.
 
 # nanonext 1.2.1

--- a/src/core.c
+++ b/src/core.c
@@ -149,6 +149,16 @@ void sendaio_complete(void *arg) {
 
 }
 
+void cv_finalizer(SEXP xptr) {
+
+  if (NANO_PTR(xptr) == NULL) return;
+  nano_cv *xp = (nano_cv *) NANO_PTR(xptr);
+  nng_cv_free(xp->cv);
+  nng_mtx_free(xp->mtx);
+  R_Free(xp);
+
+}
+
 void dialer_finalizer(SEXP xptr) {
 
   if (NANO_PTR(xptr) == NULL) return;
@@ -163,10 +173,8 @@ void dialer_finalizer(SEXP xptr) {
 void listener_finalizer(SEXP xptr) {
 
   if (NANO_PTR(xptr) == NULL) return;
-  nano_listener *xp = (nano_listener *) NANO_PTR(xptr);
-  nng_listener_close(xp->list);
-  if (xp->tls != NULL)
-    nng_tls_config_free(xp->tls);
+  nng_listener *xp = (nng_listener *) NANO_PTR(xptr);
+  nng_listener_close(*xp);
   R_Free(xp);
 
 }
@@ -180,13 +188,11 @@ void socket_finalizer(SEXP xptr) {
 
 }
 
-void cv_finalizer(SEXP xptr) {
+void tls_finalizer(SEXP xptr) {
 
   if (NANO_PTR(xptr) == NULL) return;
-  nano_cv *xp = (nano_cv *) NANO_PTR(xptr);
-  nng_cv_free(xp->cv);
-  nng_mtx_free(xp->mtx);
-  R_Free(xp);
+  nng_tls_config *xp = (nng_tls_config *) NANO_PTR(xptr);
+  nng_tls_config_free(xp);
 
 }
 

--- a/src/core.c
+++ b/src/core.c
@@ -162,10 +162,8 @@ void cv_finalizer(SEXP xptr) {
 void dialer_finalizer(SEXP xptr) {
 
   if (NANO_PTR(xptr) == NULL) return;
-  nano_dialer *xp = (nano_dialer *) NANO_PTR(xptr);
-  nng_dialer_close(xp->dial);
-  if (xp->tls != NULL)
-    nng_tls_config_free(xp->tls);
+  nng_dialer *xp = (nng_dialer *) NANO_PTR(xptr);
+  nng_dialer_close(*xp);
   R_Free(xp);
 
 }

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -137,11 +137,6 @@ typedef union nano_opt_u {
   uint64_t u;
 } nano_opt;
 
-typedef struct nano_dialer_s {
-  nng_dialer dial;
-  nng_tls_config *tls;
-} nano_dialer;
-
 typedef struct nano_stream_s {
   nng_stream *stream;
   union {

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -137,11 +137,6 @@ typedef union nano_opt_u {
   uint64_t u;
 } nano_opt;
 
-typedef struct nano_listener_s {
-  nng_listener list;
-  nng_tls_config *tls;
-} nano_listener;
-
 typedef struct nano_dialer_s {
   nng_dialer dial;
   nng_tls_config *tls;
@@ -303,6 +298,7 @@ int nano_matcharg(const SEXP);
 int nano_matchargs(const SEXP);
 
 void pipe_cb_signal(nng_pipe, nng_pipe_ev, void *);
+void tls_finalizer(SEXP);
 
 SEXP rnng_advance_rng_state(void);
 SEXP rnng_aio_call(SEXP);

--- a/src/thread.c
+++ b/src/thread.c
@@ -115,15 +115,15 @@ SEXP rnng_messenger(SEXP url) {
 
   const char *up = CHAR(STRING_ELT(url, 0));
   nng_socket *sock = R_Calloc(1, nng_socket);
-  nano_listener *lp;
+  nng_listener *lp;
   nano_dialer *dp;
   int xc, dialer = 0;
   SEXP socket, con;
 
   if ((xc = nng_pair0_open(sock)))
     goto exitlevel1;
-  lp = R_Calloc(1, nano_listener);
-  if ((xc = nng_listen(*sock, up, &lp->list, 0))) {
+  lp = R_Calloc(1, nng_listener);
+  if ((xc = nng_listen(*sock, up, lp, 0))) {
     if (xc != 10 && xc != 15) {
       R_Free(lp);
       goto exitlevel1;
@@ -699,7 +699,7 @@ SEXP rnng_dispatcher_socket(SEXP host, SEXP url, SEXP tls) {
     memcpy(disp->url[i], up, slen);
   }
   nng_socket *hsock = R_Calloc(1, nng_socket);
-  nano_listener *hl = R_Calloc(1, nano_listener);
+  nng_listener *hl = R_Calloc(1, nng_listener);
 
   if (nng_url_parse(&disp->up, disp->url[0]))
     goto exitlevel3;
@@ -708,7 +708,7 @@ SEXP rnng_dispatcher_socket(SEXP host, SEXP url, SEXP tls) {
     goto exitlevel4;
 
   if ((xc = nng_socket_set_ms(*hsock, "req:resend-time", 0)) ||
-      (xc = nng_listen(*hsock, disp->host, &hl->list, 0)) ||
+      (xc = nng_listen(*hsock, disp->host, hl, 0)) ||
       (xc = nng_thread_create(&disp->thr, rnng_dispatch_thread, disp)))
     goto exitlevel5;
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -116,7 +116,7 @@ SEXP rnng_messenger(SEXP url) {
   const char *up = CHAR(STRING_ELT(url, 0));
   nng_socket *sock = R_Calloc(1, nng_socket);
   nng_listener *lp;
-  nano_dialer *dp;
+  nng_dialer *dp;
   int xc, dialer = 0;
   SEXP socket, con;
 
@@ -129,8 +129,8 @@ SEXP rnng_messenger(SEXP url) {
       goto exitlevel1;
     }
     R_Free(lp);
-    dp = R_Calloc(1, nano_dialer);
-    if ((xc = nng_dial(*sock, up, &dp->dial, 0))) {
+    dp = R_Calloc(1, nng_dialer);
+    if ((xc = nng_dial(*sock, up, dp, 0))) {
       R_Free(dp);
       goto exitlevel1;
     }

--- a/src/tls.c
+++ b/src/tls.c
@@ -76,16 +76,6 @@ static int parse_serial_decimal_format(unsigned char *obuf, size_t obufmax,
 }
 #endif
 
-// finalizers ------------------------------------------------------------------
-
-static void tls_finalizer(SEXP xptr) {
-
-  if (NANO_PTR(xptr) == NULL) return;
-  nng_tls_config *xp = (nng_tls_config *) NANO_PTR(xptr);
-  nng_tls_config_free(xp);
-
-}
-
 // Mbed TLS Random Data Generator ----------------------------------------------
 
 SEXP rnng_random(SEXP n, SEXP convert) {


### PR DESCRIPTION
Refactors listener and dialers to no longer wrap the underlying structs.

This was only required to keep a reference to the associated tls configuration where present. We can tie the object lifetimes together using the PTR_PROT field of the SEXP instead.

This is more efficient for inproc/ipc/tcp everywhere where TLS is not relevant. Even for TLS, this provides for a cleaner and simpler approach.