### PR TITLE
Remove interactive status updates from `write_cert()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nanonext
 Type: Package
 Title: NNG (Nanomsg Next Gen) Lightweight Messaging Library
-Version: 1.4.0.9002
+Version: 1.4.0.9003
 Description: R binding for NNG (Nanomsg Next Gen), a successor to ZeroMQ. NNG is
     a socket library implementing 'Scalability Protocols', a reliable,
     high-performance standard for common communications patterns including

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
-# nanonext 1.4.0.9002 (development)
+# nanonext 1.4.0.9003 (development)
 
 #### Updates
 
+* `write_cert()` no longer displays a status message when interactive (thanks @wlandau, #74).
 * Removes partial matching when using `$`, `[[` or `[` on an object inheriting from class 'nano'.
 
 # nanonext 1.4.0

--- a/R/tls.R
+++ b/R/tls.R
@@ -77,9 +77,6 @@ tls_config <- function(client = NULL, server = NULL, pass = NULL, auth = is.null
 #' Generate self-signed x509 certificate and 4096 bit RSA private/public key
 #' pair for use with authenticated, encrypted TLS communications.
 #'
-#' For interactive sessions only, a status message is printed at the start of
-#' key / certificate generation and also when complete.
-#'
 #' @param cn [default 'localhost'] character issuer common name (CN) for the
 #'   certificate. This can be either a hostname or an IP address, but must match
 #'   the actual server URL as client authentication will depend on it.
@@ -115,4 +112,4 @@ tls_config <- function(client = NULL, server = NULL, pass = NULL, auth = is.null
 #' @export
 #'
 write_cert <- function(cn = "localhost", valid = "20301231235959")
-  .Call(rnng_write_cert, cn, valid, interactive())
+  .Call(rnng_write_cert, cn, valid)

--- a/R/tls.R
+++ b/R/tls.R
@@ -77,6 +77,9 @@ tls_config <- function(client = NULL, server = NULL, pass = NULL, auth = is.null
 #' Generate self-signed x509 certificate and 4096 bit RSA private/public key
 #' pair for use with authenticated, encrypted TLS communications.
 #'
+#' Note that it can take a second or two for the key and certificate to be
+#' generated.
+#'
 #' @param cn [default 'localhost'] character issuer common name (CN) for the
 #'   certificate. This can be either a hostname or an IP address, but must match
 #'   the actual server URL as client authentication will depend on it.

--- a/man/write_cert.Rd
+++ b/man/write_cert.Rd
@@ -24,10 +24,6 @@ A list of length 2, comprising \code{$server} and \code{$client}.
 Generate self-signed x509 certificate and 4096 bit RSA private/public key
 pair for use with authenticated, encrypted TLS communications.
 }
-\details{
-For interactive sessions only, a status message is printed at the start of
-key / certificate generation and also when complete.
-}
 \examples{
 
 if (interactive()) {

--- a/man/write_cert.Rd
+++ b/man/write_cert.Rd
@@ -24,6 +24,10 @@ A list of length 2, comprising \code{$server} and \code{$client}.
 Generate self-signed x509 certificate and 4096 bit RSA private/public key
 pair for use with authenticated, encrypted TLS communications.
 }
+\details{
+Note that it can take a second or two for the key and certificate to be
+generated.
+}
 \examples{
 
 if (interactive()) {

--- a/src/init.c
+++ b/src/init.c
@@ -198,7 +198,7 @@ static const R_CallMethodDef callMethods[] = {
   {"rnng_url_parse", (DL_FUNC) &rnng_url_parse, 1},
   {"rnng_version", (DL_FUNC) &rnng_version, 0},
   {"rnng_wait_thread_create", (DL_FUNC) &rnng_wait_thread_create, 1},
-  {"rnng_write_cert", (DL_FUNC) &rnng_write_cert, 3},
+  {"rnng_write_cert", (DL_FUNC) &rnng_write_cert, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -370,6 +370,6 @@ SEXP rnng_unresolved2(SEXP);
 SEXP rnng_url_parse(SEXP);
 SEXP rnng_version(void);
 SEXP rnng_wait_thread_create(SEXP);
-SEXP rnng_write_cert(SEXP, SEXP, SEXP);
+SEXP rnng_write_cert(SEXP, SEXP);
 
 #endif


### PR DESCRIPTION
Closes #74.

Somewhat incongruent behaviour in this function - should return silently. A user prompt can be generated by the consuming package, just once at the start and once at the end. It was never very useful to show progress when the entire operation lasted 1-2s.