### PR TITLE
Fixes for `messenger()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 #### Updates
 
 * `write_cert()` argument 'cn' now defaults to '127.0.0.1' instead of 'localhost'.
-* A 'req' socket with 'req:resend-time' set as 0 now efficiently frees the message as soon as the send has completed.
+* `messenger()` now exits cleanly, correcting a regression in nanonext 1.5.0 (#87).
+* A 'req' socket with option 'req:resend-time' set as 0 now efficiently frees the message as soon as the send has completed.
 * Bundled 'libnng' updated to 1.10.2 pre-release.
 
 # nanonext 1.5.1

--- a/R/messenger.R
+++ b/R/messenger.R
@@ -60,7 +60,7 @@ messenger <- function(url, auth = NULL) {
   sock <- .Call(rnng_messenger, url)
   on.exit(expr = {
     send(sock, data = writeBin(":d ", raw()), mode = 2L, block = FALSE)
-    close(sock)
+    reap(sock)
   })
   cat("\n", file = stdout())
   intro <- unlist(strsplit("nanonext messenger", ""))


### PR DESCRIPTION
Fixes #87. No close method for class 'externalptr'.