### PR TITLE
More robust interrupt if supplied to daemon() 'autoexit' (POSIX)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nanonext (development version)
 
+#### Updates
+
+* More robust interruption on non-Windows platforms if `tools::SIGINT` is supplied or passed through to the `autoexit` argument of `daemon()` (thanks @LennardLux, #97).
+
 # nanonext 1.5.2
 
 #### Updates

--- a/src/sync.c
+++ b/src/sync.c
@@ -110,6 +110,8 @@ void pipe_cb_signal(nng_pipe p, nng_pipe_ev ev, void *arg) {
 #ifdef _WIN32
     raise(sig);
 #else
+    if (sig == SIGINT)
+      R_interrupts_pending = 1;
     kill(getpid(), sig);
 #endif
 


### PR DESCRIPTION
Porting the fix from #98.

Closes #97.