### PR TITLE
Migrate to NNG 2.0-compatible APIs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^compile_commands\.json$
 ^\.cache$
 ^cran-comments\.md$
+^CLAUDE.md$


### PR DESCRIPTION
The NNG 2.0 API is not compatible in quite a few cases, but where the APIs already exist, we should migrate as much as possible beforehand to minimize the changes.

Doing a `recv()` using `NNG_FLAG_ALLOC` directly into a buffer is no longer possible in NNG 2.0. Instead the more 'modern' (and performant) way to do things is via `nng_recvmsg()`.

FYI @lionel- this is just the start. The non-compatible changes will be done on a new branch, and we will bundle NNG 2.0 there so that we don't need to maintain multiple code paths for compatibility.