### PR TITLE
Reduce memory usage during message encoding / serialization

### DIFF
--- a/src/aio.c
+++ b/src/aio.c
@@ -625,26 +625,27 @@ SEXP rnng_send_aio(SEXP con, SEXP data, SEXP mode, SEXP timeout, SEXP pipe, SEXP
   const int raw = nano_encode_mode(mode);
   SEXP aio, env, fun;
   nano_aio *saio = NULL;
-  nano_buf buf;
   int sock, xc;
 
   if ((sock = !NANO_PTR_CHECK(con, nano_SocketSymbol)) || !NANO_PTR_CHECK(con, nano_ContextSymbol)) {
 
     const int pipeid = sock ? nano_integer(pipe) : 0;
-    if (raw) {
-      nano_encode(&buf, data);
-    } else {
-      nano_serialize(&buf, data, NANO_PROT(con), 0);
-    }
     nng_msg *msg = NULL;
 
     saio = calloc(1, sizeof(nano_aio));
     NANO_ENSURE_ALLOC(saio);
     saio->type = SENDAIO;
 
-    if ((xc = nng_msg_alloc(&msg, 0)) ||
-        (xc = nng_msg_append(msg, buf.buf, buf.cur)) ||
-        (xc = nng_aio_alloc(&saio->aio, saio_complete, saio))) {
+    if ((xc = nng_msg_alloc(&msg, 0)))
+      goto fail;
+
+    if (raw) {
+      nano_encode(msg, data);
+    } else {
+      nano_serialize(msg, data, NANO_PROT(con), 0);
+    }
+
+    if ((xc = nng_aio_alloc(&saio->aio, saio_complete, saio))) {
       nng_msg_free(msg);
       goto fail;
     }
@@ -659,14 +660,14 @@ SEXP rnng_send_aio(SEXP con, SEXP data, SEXP mode, SEXP timeout, SEXP pipe, SEXP
     nng_aio_set_timeout(saio->aio, dur);
     sock ? nng_send_aio(*(nng_socket *) NANO_PTR(con), saio->aio) :
            nng_ctx_send(*(nng_ctx *) NANO_PTR(con), saio->aio);
-    NANO_FREE(buf);
 
     PROTECT(aio = R_MakeExternalPtr(saio, nano_AioSymbol, R_NilValue));
     R_RegisterCFinalizerEx(aio, saio_finalizer, TRUE);
 
   } else if (!NANO_PTR_CHECK(con, nano_StreamSymbol)) {
 
-    nano_encode(&buf, data);
+    nano_buf buf;
+    nano_encode_buf(&buf, data);
 
     nano_stream *nst = (nano_stream *) NANO_PTR(con);
     nng_stream *sp = nst->stream;
@@ -683,8 +684,10 @@ SEXP rnng_send_aio(SEXP con, SEXP data, SEXP mode, SEXP timeout, SEXP pipe, SEXP
     };
 
     if ((xc = nng_aio_alloc(&saio->aio, isaio_complete, saio)) ||
-        (xc = nng_aio_set_iov(saio->aio, 1u, &iov)))
-      goto fail;
+        (xc = nng_aio_set_iov(saio->aio, 1u, &iov))) {
+          NANO_FREE(buf);
+          goto fail;
+        }
 
     nng_aio_set_timeout(saio->aio, dur);
     nng_stream_send(sp, saio->aio);
@@ -711,7 +714,6 @@ SEXP rnng_send_aio(SEXP con, SEXP data, SEXP mode, SEXP timeout, SEXP pipe, SEXP
   nng_aio_free(saio->aio);
   free(saio->data);
   failmem:
-  NANO_FREE(buf);
   free(saio);
   return mk_error_data(-xc);
 

--- a/src/comms.c
+++ b/src/comms.c
@@ -335,54 +335,41 @@ SEXP rnng_send(SEXP con, SEXP data, SEXP mode, SEXP block, SEXP pipe) {
 
   const int flags = block == R_NilValue ? NNG_DURATION_DEFAULT : TYPEOF(block) == LGLSXP ? 0 : nano_integer(block);
   const int raw = nano_encode_mode(mode);
-  nano_buf buf;
   int sock, xc;
 
   if ((sock = !NANO_PTR_CHECK(con, nano_SocketSymbol)) || !NANO_PTR_CHECK(con, nano_ContextSymbol)) {
 
     const int pipeid = sock ? nano_integer(pipe) : 0;
-    if (raw) {
-      nano_encode(&buf, data);
-    } else {
-      nano_serialize(&buf, data, NANO_PROT(con), 0);
-    }
     nng_msg *msgp = NULL;
+
+    if ((xc = nng_msg_alloc(&msgp, 0)))
+      goto fail;
+
+    if (raw) {
+      nano_encode(msgp, data);
+    } else {
+      nano_serialize(msgp, data, NANO_PROT(con), 0);
+    }
+
+    if (pipeid) {
+      nng_pipe p;
+      p.id = (uint32_t) pipeid;
+      nng_msg_set_pipe(msgp, p);
+    }
 
     if (flags <= 0) {
 
-      if ((xc = nng_msg_alloc(&msgp, 0)))
-        goto fail;
-
-      if (pipeid) {
-        nng_pipe p;
-        p.id = (uint32_t) pipeid;
-        nng_msg_set_pipe(msgp, p);
-      }
-
-      if ((xc = nng_msg_append(msgp, buf.buf, buf.cur)) ||
-          (xc = sock ? nng_sendmsg(*(nng_socket *) NANO_PTR(con), msgp, flags ? NNG_FLAG_NONBLOCK : (NANO_INTEGER(block) != 1) * NNG_FLAG_NONBLOCK) :
+      if ((xc = sock ? nng_sendmsg(*(nng_socket *) NANO_PTR(con), msgp, flags ? NNG_FLAG_NONBLOCK : (NANO_INTEGER(block) != 1) * NNG_FLAG_NONBLOCK) :
                        nng_ctx_sendmsg(*(nng_ctx *) NANO_PTR(con), msgp, flags ? NNG_FLAG_NONBLOCK : (NANO_INTEGER(block) != 1) * NNG_FLAG_NONBLOCK))) {
         nng_msg_free(msgp);
         goto fail;
       }
 
-      NANO_FREE(buf);
-
     } else {
 
       nng_aio *aiop = NULL;
 
-      if ((xc = nng_msg_alloc(&msgp, 0)))
-        goto fail;
-
-      if (pipeid) {
-        nng_pipe p;
-        p.id = (uint32_t) pipeid;
-        nng_msg_set_pipe(msgp, p);
-      }
-
-      if ((xc = nng_msg_append(msgp, buf.buf, buf.cur)) ||
-          (xc = nng_aio_alloc(&aiop, NULL, NULL))) {
+      if ((xc = nng_aio_alloc(&aiop, NULL, NULL))) {
         nng_msg_free(msgp);
         goto fail;
       }
@@ -391,7 +378,6 @@ SEXP rnng_send(SEXP con, SEXP data, SEXP mode, SEXP block, SEXP pipe) {
       nng_aio_set_timeout(aiop, flags);
       sock ? nng_send_aio(*(nng_socket *) NANO_PTR(con), aiop) :
              nng_ctx_send(*(nng_ctx *) NANO_PTR(con), aiop);
-      NANO_FREE(buf);
       nng_aio_wait(aiop);
       if ((xc = nng_aio_result(aiop)))
         nng_msg_free(nng_aio_get_msg(aiop));
@@ -401,7 +387,8 @@ SEXP rnng_send(SEXP con, SEXP data, SEXP mode, SEXP block, SEXP pipe) {
 
   } else if (!NANO_PTR_CHECK(con, nano_StreamSymbol)) {
 
-    nano_encode(&buf, data);
+    nano_buf buf;
+    nano_encode_buf(&buf, data);
 
     nano_stream *nst = (nano_stream *) NANO_PTR(con);
     nng_stream *sp = nst->stream;
@@ -411,11 +398,14 @@ SEXP rnng_send(SEXP con, SEXP data, SEXP mode, SEXP block, SEXP pipe) {
       .iov_len = buf.cur - nst->textframes
     };
 
-    if ((xc = nng_aio_alloc(&aiop, NULL, NULL)))
+    if ((xc = nng_aio_alloc(&aiop, NULL, NULL))) {
+      NANO_FREE(buf);
       goto fail;
+    }
 
     if ((xc = nng_aio_set_iov(aiop, 1u, &iov))) {
       nng_aio_free(aiop);
+      NANO_FREE(buf);
       goto fail;
     }
 
@@ -436,7 +426,6 @@ SEXP rnng_send(SEXP con, SEXP data, SEXP mode, SEXP block, SEXP pipe) {
   return nano_success;
 
   fail:
-  NANO_FREE(buf);
   return mk_error(xc);
 
 }

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -230,7 +230,7 @@ typedef struct nano_serial_bundle_s {
   R_outpstream_t outpstream;
   R_inpstream_t inpstream;
   SEXP klass;
-  unsigned char *buf;
+  nng_msg *msg;
 } nano_serial_bundle;
 
 typedef enum nano_list_op {
@@ -320,10 +320,11 @@ void haio_invoke_cb(void *);
 SEXP mk_error(const int);
 SEXP mk_error_data(const int);
 SEXP nano_raw_char(const unsigned char *, const size_t);
-void nano_serialize(nano_buf *, const SEXP, SEXP, int);
+void nano_serialize(nng_msg *, const SEXP, SEXP, int);
 SEXP nano_unserialize(unsigned char *, const size_t, SEXP);
 SEXP nano_decode(unsigned char *, const size_t, const uint8_t, SEXP);
-void nano_encode(nano_buf *, const SEXP);
+void nano_encode(nng_msg *, const SEXP);
+void nano_encode_buf(nano_buf *, const SEXP);
 int nano_encode_mode(const SEXP);
 int nano_matcharg(const SEXP);
 SEXP nano_aio_result(SEXP);

--- a/src/thread.c
+++ b/src/thread.c
@@ -102,10 +102,18 @@ static void rnng_messenger_thread(void *args) {
                     tms->tm_year + 1900, tms->tm_mon + 1, tms->tm_mday,
                     tms->tm_hour, tms->tm_min, tms->tm_sec);
         nng_msg_free(msgp);
-        nano_buf enc;
-        nano_encode(&enc, key);
-        xc = nng_send(*sock, enc.buf, enc.cur, NNG_FLAG_NONBLOCK);
+        nng_msg *msg = NULL;
+        if ((xc = nng_msg_alloc(&msg, 0))) {
+          nano_printf(1,
+                      "| messenger session ended: %d-%02d-%02d %02d:%02d:%02d\n",
+                      tms->tm_year + 1900, tms->tm_mon + 1, tms->tm_mday,
+                      tms->tm_hour, tms->tm_min, tms->tm_sec);
+          break;
+        }
+        nano_encode(msg, key);
+        xc = nng_sendmsg(*sock, msg, NNG_FLAG_NONBLOCK);
         if (xc) {
+          nng_msg_free(msg);
           nano_printf(1,
                       "| messenger session ended: %d-%02d-%02d %02d:%02d:%02d\n",
                       tms->tm_year + 1900, tms->tm_mon + 1, tms->tm_mday,

--- a/src/utils.c
+++ b/src/utils.c
@@ -329,13 +329,13 @@ SEXP rnng_subscribe(SEXP object, SEXP value, SEXP sub) {
   if (!NANO_PTR_CHECK(object, nano_SocketSymbol)) {
 
     nng_socket *sock = (nng_socket *) NANO_PTR(object);
-    nano_encode(&buf, value);
+    nano_encode_buf(&buf, value);
     xc = nng_socket_set(*sock, op, buf.buf, buf.cur - (TYPEOF(value) == STRSXP));
 
   } else if (!NANO_PTR_CHECK(object, nano_ContextSymbol)) {
 
     nng_ctx *ctx = (nng_ctx *) NANO_PTR(object);
-    nano_encode(&buf, value);
+    nano_encode_buf(&buf, value);
     xc = nng_ctx_set(*ctx, op, buf.buf, buf.cur - (TYPEOF(value) == STRSXP));
 
   } else {


### PR DESCRIPTION
Closes #219.

This PR allocates a `nng_msg` upfront and uses `nng_msg_append()` directly in all the internal encoding and serialization functions to avoid allocation of an intermediate object and memcpy - reducing peak memory usage.

Previously, we used a `nano_buf` struct (similar to base R's `membuf`). This held the serialized object before being appended in its entirety to an `nng_msg`. This would perform a `memcpy()` on the object - a real one, not one that would be optimized away by the compiler.

Note: we still retain the use of `nano_buf` in places such as stream sends which are not `nng_msg` based.

FYI @lionel-