### PR TITLE
Revert "Reduce memory usage during message encoding / serialization"

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -13,9 +13,8 @@ static SEXP nano_eval_prot (void *call) {
 }
 
 static void nano_cleanup(void *data, Rboolean jump) {
-  if (jump) {
-    nng_msg_free((nng_msg *) data);
-  }
+  if (jump)
+    free(data);
 }
 
 static void nano_eval_safe (void *call) {
@@ -24,11 +23,27 @@ static void nano_eval_safe (void *call) {
 
 static void nano_write_bytes(R_outpstream_t stream, void *src, int len) {
 
-  nng_msg *msg = (nng_msg *) stream->data;
-  if (nng_msg_append(msg, src, (size_t) len)) {
-    nng_msg_free(msg);
-    Rf_error("serialization failed");
+  nano_buf *buf = (nano_buf *) stream->data;
+
+  size_t req = buf->cur + (size_t) len;
+  if (req > buf->len) {
+    if (req > R_XLEN_T_MAX) {
+      if (buf->len) free(buf->buf);
+      Rf_error("serialization exceeds max length of raw vector");
+    }
+    do {
+      buf->len += buf->len > NANONEXT_SERIAL_THR ? NANONEXT_SERIAL_THR : buf->len;
+    } while (buf->len < req);
+    unsigned char *nbuf = realloc(buf->buf, buf->len);
+    if (nbuf == NULL) {
+      free(buf->buf);
+      Rf_error("memory allocation failed");
+    }
+    buf->buf = nbuf;
   }
+
+  memcpy(buf->buf + buf->cur, src, len);
+  buf->cur += len;
 
 }
 
@@ -96,10 +111,10 @@ static SEXP nano_serialize_hook(SEXP x, SEXP hook_func) {
 
   SEXP out, call;
   PROTECT(call = Rf_lcons(NANO_VECTOR(hook_func)[i], Rf_cons(x, R_NilValue)));
-  out = R_UnwindProtect(nano_eval_prot, call, nano_cleanup, nano_bundle.msg, NULL);
+  out = R_UnwindProtect(nano_eval_prot, call, nano_cleanup, nano_bundle.buf, NULL);
   UNPROTECT(1);
   if (TYPEOF(out) != RAWSXP) {
-    nng_msg_free(nano_bundle.msg);
+    free(nano_bundle.buf);
     Rf_error("Serialization function for `%s` did not return a raw vector", NANO_STR_N(klass, i));
   }
 
@@ -244,28 +259,28 @@ SEXP nano_raw_char(const unsigned char *buf, const size_t sz) {
 
 }
 
-void nano_serialize(nng_msg *msg, SEXP object, SEXP hook, int header) {
+void nano_serialize(nano_buf *buf, SEXP object, SEXP hook, int header) {
 
+  NANO_ALLOC(buf, NANONEXT_INIT_BUFSIZE);
   struct R_outpstream_st output_stream;
 
   if (header || special_marker) {
-    unsigned char magic[4] = {0x7, 0x0, 0x0, (uint8_t) special_marker};
-    if (nng_msg_append(msg, magic, sizeof(magic)) ||
-        nng_msg_append(msg, &header, sizeof(int))) {
-      nng_msg_free(msg);
-      Rf_error("serialization failed");
-    }
+    buf->buf[0] = 0x7;
+    buf->buf[3] = (uint8_t) special_marker;
+    if (header)
+      memcpy(buf->buf + 4, &header, sizeof(int));
+    buf->cur += 8;
   }
 
   if (hook != R_NilValue) {
     nano_bundle.klass = NANO_VECTOR(hook)[0];
     nano_bundle.outpstream = &output_stream;
-    nano_bundle.msg = msg;
+    nano_bundle.buf = buf->buf;
   }
 
   R_InitOutPStream(
     &output_stream,
-    (R_pstream_data_t) msg,
+    (R_pstream_data_t) buf,
     R_pstream_binary_format,
     NANONEXT_SERIAL_VER,
     NULL,
@@ -414,62 +429,10 @@ SEXP nano_decode(unsigned char *buf, const size_t sz, const uint8_t mod, SEXP ho
 
 }
 
-void nano_encode(nng_msg *msg, const SEXP object) {
+void nano_encode(nano_buf *enc, const SEXP object) {
 
   switch (TYPEOF(object)) {
-  case STRSXP: {
-    R_xlen_t xlen = XLENGTH(object);
-    if (xlen == 1) {
-      const char *s = NANO_STRING(object);
-      size_t slen = strlen(s) + 1;
-      if (nng_msg_append(msg, s, slen))
-        goto fail;
-    } else {
-      for (R_xlen_t i = 0; i < xlen; i++) {
-        const char *s = NANO_STR_N(object, i);
-        size_t slen = strlen(s) + 1;
-        if (nng_msg_append(msg, s, slen))
-          goto fail;
-      }
-    }
-    break;
-  }
-  case REALSXP:
-    if (nng_msg_append(msg, DATAPTR_RO(object), XLENGTH(object) * sizeof(double)))
-      goto fail;
-    break;
-  case INTSXP:
-  case LGLSXP:
-    if (nng_msg_append(msg, DATAPTR_RO(object), XLENGTH(object) * sizeof(int)))
-      goto fail;
-    break;
-  case CPLXSXP:
-    if (nng_msg_append(msg, DATAPTR_RO(object), XLENGTH(object) * 2 * sizeof(double)))
-      goto fail;
-    break;
-  case RAWSXP:
-    if (nng_msg_append(msg, DATAPTR_RO(object), XLENGTH(object)))
-      goto fail;
-    break;
-  case NILSXP:
-    break;
-  default:
-    nng_msg_free(msg);
-    Rf_error("`data` must be an atomic vector type or NULL to send in mode 'raw'");
-  }
-
-  return;
-
-  fail:
-  nng_msg_free(msg);
-  Rf_error("encode failed");
-
-}
-
-void nano_encode_buf(nano_buf *enc, const SEXP object) {
-
-  switch (TYPEOF(object)) {
-  case STRSXP: {
+  case STRSXP: ;
     const char *s;
     R_xlen_t xlen = XLENGTH(object);
     if (xlen == 1) {
@@ -489,7 +452,6 @@ void nano_encode_buf(nano_buf *enc, const SEXP object) {
       enc->cur += slen;
     }
     break;
-  }
   case REALSXP:
     NANO_INIT(enc, (unsigned char *) DATAPTR_RO(object), XLENGTH(object) * sizeof(double));
     break;

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -230,7 +230,7 @@ typedef struct nano_serial_bundle_s {
   R_outpstream_t outpstream;
   R_inpstream_t inpstream;
   SEXP klass;
-  nng_msg *msg;
+  unsigned char *buf;
 } nano_serial_bundle;
 
 typedef enum nano_list_op {
@@ -320,11 +320,10 @@ void haio_invoke_cb(void *);
 SEXP mk_error(const int);
 SEXP mk_error_data(const int);
 SEXP nano_raw_char(const unsigned char *, const size_t);
-void nano_serialize(nng_msg *, const SEXP, SEXP, int);
+void nano_serialize(nano_buf *, const SEXP, SEXP, int);
 SEXP nano_unserialize(unsigned char *, const size_t, SEXP);
 SEXP nano_decode(unsigned char *, const size_t, const uint8_t, SEXP);
-void nano_encode(nng_msg *, const SEXP);
-void nano_encode_buf(nano_buf *, const SEXP);
+void nano_encode(nano_buf *, const SEXP);
 int nano_encode_mode(const SEXP);
 int nano_matcharg(const SEXP);
 SEXP nano_aio_result(SEXP);

--- a/src/sync.c
+++ b/src/sync.c
@@ -474,6 +474,13 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
   nano_aio *raio = NULL;
   nng_msg *msg = NULL;
   SEXP aio, env, fun;
+  nano_buf buf;
+
+  if (raw) {
+    nano_encode(&buf, data);
+  } else {
+    nano_serialize(&buf, data, NANO_PROT(con), id);
+  }
 
   saio = calloc(1, sizeof(nano_saio));
   NANO_ENSURE_ALLOC(saio);
@@ -484,16 +491,9 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
   saio->ctx = ctx;
   saio->id = msgid != R_NilValue ? id : mod != 1 ? -id : 0;
 
-  if ((xc = nng_msg_alloc(&msg, 0)))
-    goto fail;
-
-  if (raw) {
-    nano_encode(msg, data);
-  } else {
-    nano_serialize(msg, data, NANO_PROT(con), id);
-  }
-
-  if ((xc = nng_aio_alloc(&saio->aio, sendaio_complete, saio))) {
+  if ((xc = nng_msg_alloc(&msg, 0)) ||
+      (xc = nng_msg_append(msg, buf.buf, buf.cur)) ||
+      (xc = nng_aio_alloc(&saio->aio, sendaio_complete, saio))) {
     nng_msg_free(msg);
     goto fail;
   }
@@ -511,6 +511,7 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
 
   nng_aio_set_timeout(raio->aio, dur);
   nng_ctx_recv(*ctx, raio->aio);
+  NANO_FREE(buf);
 
   PROTECT(aio = R_MakeExternalPtr(raio, nano_AioSymbol, NANO_PROT(con)));
   R_RegisterCFinalizerEx(aio, request_finalizer, TRUE);
@@ -532,6 +533,7 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
   failmem:
   free(raio);
   free(saio);
+  NANO_FREE(buf);
   return mk_error_data(xc);
 
 }

--- a/src/thread.c
+++ b/src/thread.c
@@ -102,18 +102,10 @@ static void rnng_messenger_thread(void *args) {
                     tms->tm_year + 1900, tms->tm_mon + 1, tms->tm_mday,
                     tms->tm_hour, tms->tm_min, tms->tm_sec);
         nng_msg_free(msgp);
-        nng_msg *msg = NULL;
-        if ((xc = nng_msg_alloc(&msg, 0))) {
-          nano_printf(1,
-                      "| messenger session ended: %d-%02d-%02d %02d:%02d:%02d\n",
-                      tms->tm_year + 1900, tms->tm_mon + 1, tms->tm_mday,
-                      tms->tm_hour, tms->tm_min, tms->tm_sec);
-          break;
-        }
-        nano_encode(msg, key);
-        xc = nng_sendmsg(*sock, msg, NNG_FLAG_NONBLOCK);
+        nano_buf enc;
+        nano_encode(&enc, key);
+        xc = nng_send(*sock, enc.buf, enc.cur, NNG_FLAG_NONBLOCK);
         if (xc) {
-          nng_msg_free(msg);
           nano_printf(1,
                       "| messenger session ended: %d-%02d-%02d %02d:%02d:%02d\n",
                       tms->tm_year + 1900, tms->tm_mon + 1, tms->tm_mday,

--- a/src/utils.c
+++ b/src/utils.c
@@ -329,13 +329,13 @@ SEXP rnng_subscribe(SEXP object, SEXP value, SEXP sub) {
   if (!NANO_PTR_CHECK(object, nano_SocketSymbol)) {
 
     nng_socket *sock = (nng_socket *) NANO_PTR(object);
-    nano_encode_buf(&buf, value);
+    nano_encode(&buf, value);
     xc = nng_socket_set(*sock, op, buf.buf, buf.cur - (TYPEOF(value) == STRSXP));
 
   } else if (!NANO_PTR_CHECK(object, nano_ContextSymbol)) {
 
     nng_ctx *ctx = (nng_ctx *) NANO_PTR(object);
-    nano_encode_buf(&buf, value);
+    nano_encode(&buf, value);
     xc = nng_ctx_set(*ctx, op, buf.buf, buf.cur - (TYPEOF(value) == STRSXP));
 
   } else {


### PR DESCRIPTION
Reverts r-lib/nanonext#220

Empirical testing (on Linux) resulted in:
- large performance regression, for which use of `nng_msg_reserve()` would be required
- in which case, no measurable reduction in peak memory usage