### PR TITLE
Performance: serialization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # nanonext (development version)
 
 * Fixes a potential crash when a serialization hook errors (#225).
-* Performance improvements for async sends.
+* Performance improvements for serialization and async sends.
 * Building from source no longer requires `xz`.
 
 # nanonext 1.7.2

--- a/src/core.c
+++ b/src/core.c
@@ -265,6 +265,7 @@ void nano_serialize(nano_buf *buf, SEXP object, SEXP hook, int header) {
   struct R_outpstream_st output_stream;
 
   if (header || special_marker) {
+    memset(buf->buf, 0, 8);
     buf->buf[0] = 0x7;
     buf->buf[3] = (uint8_t) special_marker;
     if (header)

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -126,7 +126,7 @@ extern int R_interrupts_pending;
 #define NANONEXT_WAIT_DUR 1000
 #define NANONEXT_SLEEP_DUR 200
 #define NANO_ALLOC(x, sz)                                      \
-  (x)->buf = calloc(sz, sizeof(unsigned char));                \
+  (x)->buf = malloc(sz);                                       \
   if ((x)->buf == NULL) Rf_error("memory allocation failed");  \
   (x)->len = sz;                                               \
   (x)->cur = 0


### PR DESCRIPTION
Use `malloc()` instread of `calloc()` for `nano_buf` allocations.