### PR TITLE
Performance: streaming

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # nanonext (development version)
 
 * Fixes a potential crash when a serialization hook errors (#225).
-* Performance improvements for serialization and async sends.
+* Performance improvements for serialization, streaming, and async sends.
 * Building from source no longer requires `xz`.
 
 # nanonext 1.7.2

--- a/src/aio.c
+++ b/src/aio.c
@@ -669,7 +669,7 @@ SEXP rnng_send_aio(SEXP con, SEXP data, SEXP mode, SEXP timeout, SEXP pipe, SEXP
     saio = calloc(1, sizeof(nano_aio));
     NANO_ENSURE_ALLOC(saio);
     saio->type = IOV_SENDAIO;
-    saio->data = calloc(buf.cur, sizeof(unsigned char));
+    saio->data = malloc(buf.cur);
     NANO_ENSURE_ALLOC(saio->data);
     memcpy(saio->data, buf.buf, buf.cur);
     nng_iov iov = {
@@ -752,7 +752,7 @@ SEXP rnng_recv_aio(SEXP con, SEXP mode, SEXP timeout, SEXP cvar, SEXP bytes, SEX
     raio->next = ncv;
     raio->type = signal ? IOV_RECVAIOS : IOV_RECVAIO;
     raio->mode = mod;
-    raio->data = calloc(xlen, sizeof(unsigned char));
+    raio->data = malloc(xlen);
     NANO_ENSURE_ALLOC(raio->data);
     nng_iov iov = {
       .iov_buf = raio->data,

--- a/src/comms.c
+++ b/src/comms.c
@@ -527,7 +527,7 @@ SEXP rnng_recv(SEXP con, SEXP mode, SEXP block, SEXP bytes) {
     nng_stream **sp = (nng_stream **) NANO_PTR(con);
     nng_aio *aiop = NULL;
 
-    buf = calloc(xlen, sizeof(unsigned char));
+    buf = malloc(xlen);
     NANO_ENSURE_ALLOC(buf);
     nng_iov iov = {
       .iov_buf = buf,

--- a/src/thread.c
+++ b/src/thread.c
@@ -599,7 +599,7 @@ SEXP rnng_read_stdin(SEXP interactive) {
   nng_listener *lp = NULL;
   sock = malloc(sizeof(nng_socket));
   NANO_ENSURE_ALLOC(sock);
-  lp = calloc(1, sizeof(nng_listener));
+  lp = malloc(sizeof(nng_listener));
   NANO_ENSURE_ALLOC(lp);
 
   if ((xc = nng_pull0_open(sock)) ||


### PR DESCRIPTION
Use `malloc()` instead of `calloc()` for buffer allocations in streaming contexts.