### PR TITLE
Safer export of macosx deployment target

### DIFF
--- a/configure
+++ b/configure
@@ -50,7 +50,8 @@ LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
 export CC CFLAGS LDFLAGS
 
 if [ -z "$MACOSX_DEPLOYMENT_TARGET" ]; then
-  export MACOSX_DEPLOYMENT_TARGET=`echo $CC | sed -En 's/.*-version-min=([0-9][0-9.]*).*/\1/p'`
+  MACOSX_DEPLOYMENT_TARGET=`echo $CC | sed -En 's/.*-version-min=([0-9][0-9.]*).*/\1/p'`
+  [ -n "$MACOSX_DEPLOYMENT_TARGET" ] && export MACOSX_DEPLOYMENT_TARGET
 fi
 
 # Detect -latomic linker flag for ARM architectures (Raspberry Pi etc.)


### PR DESCRIPTION
Prevents export of blank definition.