### PR TITLE
Expose HTTP upgrade request info in WebSocket `on_open` callback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nanonext (development version)
 
+#### Updates
+
+* `handler_ws()` `on_open` callback now receives a second argument `req`, a list containing `uri` and `headers` from the HTTP upgrade request (this is technically a breaking change).
+
 # nanonext 1.8.0
 
 #### New Features

--- a/R/server.R
+++ b/R/server.R
@@ -173,7 +173,9 @@ handler <- function(path, callback, method = "GET", prefix = FALSE) {
 #'   object and `data` is the message. Use `ws$send()` to send
 #'   responses; the return value is ignored.
 #' @param on_open \[default NULL\] Function called when a connection opens.
-#'   Signature: `function(ws)`
+#'   Signature: `function(ws, req)` where `req` is a list with `uri`
+#'   (character) and `headers` (named character vector) from the HTTP upgrade
+#'   request.
 #' @param on_close \[default NULL\] Function called when a connection closes.
 #'   Signature: `function(ws)`
 #' @param textframes \[default FALSE\] Logical, use text frames instead of binary.
@@ -205,7 +207,7 @@ handler <- function(path, callback, method = "GET", prefix = FALSE) {
 #'     # Broadcast to all
 #'     for (client in clients) client$send(data)
 #'   },
-#'   on_open = function(ws) {
+#'   on_open = function(ws, req) {
 #'     clients[[as.character(ws$id)]] <<- ws
 #'   },
 #'   on_close = function(ws) {

--- a/dev/vignettes/_v04-web.Rmd
+++ b/dev/vignettes/_v04-web.Rmd
@@ -251,7 +251,7 @@ server <- http_server(
         # Broadcast to all connected clients
         for (client in clients) client$send(data)
       },
-      on_open = function(ws) {
+      on_open = function(ws, req) {
         clients[[as.character(ws$id)]] <<- ws
       },
       on_close = function(ws) {

--- a/man/handler_ws.Rd
+++ b/man/handler_ws.Rd
@@ -21,7 +21,9 @@ object and \code{data} is the message. Use \code{ws$send()} to send
 responses; the return value is ignored.}
 
 \item{on_open}{[default NULL] Function called when a connection opens.
-Signature: \verb{function(ws)}}
+Signature: \verb{function(ws, req)} where \code{req} is a list with \code{uri}
+(character) and \code{headers} (named character vector) from the HTTP upgrade
+request.}
 
 \item{on_close}{[default NULL] Function called when a connection closes.
 Signature: \verb{function(ws)}}
@@ -62,7 +64,7 @@ h <- handler_ws(
     # Broadcast to all
     for (client in clients) client$send(data)
   },
-  on_open = function(ws) {
+  on_open = function(ws, req) {
     clients[[as.character(ws$id)]] <<- ws
   },
   on_close = function(ws) {

--- a/src/server.c
+++ b/src/server.c
@@ -187,6 +187,60 @@ static void http_server_stop(nano_http_server *srv) {
 
 // On R main thread ------------------------------------------------------------
 
+static SEXP make_ws_request_list(nng_stream *stream) {
+
+  const char *names[] = {"uri", "headers", ""};
+  SEXP request;
+  PROTECT(request = Rf_mkNamed(VECSXP, names));
+
+  char *uri_str = NULL;
+  if (nng_stream_get_string(stream, NNG_OPT_WS_REQUEST_URI, &uri_str) == 0) {
+    SET_VECTOR_ELT(request, 0, Rf_mkString(uri_str));
+    nng_strfree(uri_str);
+  }
+
+  char *headers_str = NULL;
+  if (nng_stream_get_string(stream, NNG_OPT_WS_REQUEST_HEADERS, &headers_str) == 0) {
+
+    int count = 0;
+    for (const char *p = headers_str; *p != '\0'; ) {
+      const char *eol = strstr(p, "\r\n");
+      if (eol == NULL) break;
+      if (eol > p) count++;
+      p = eol + 2;
+    }
+
+    SEXP headers = Rf_allocVector(STRSXP, count);
+    SET_VECTOR_ELT(request, 1, headers);
+    SEXP hdr_names = Rf_allocVector(STRSXP, count);
+    Rf_namesgets(headers, hdr_names);
+
+    int i = 0;
+    for (const char *p = headers_str; *p != '\0' && i < count; ) {
+      const char *eol = strstr(p, "\r\n");
+      if (eol == NULL) break;
+      if (eol > p) {
+        const char *sep = strstr(p, ": ");
+        if (sep != NULL && sep < eol) {
+          SET_STRING_ELT(hdr_names, i, Rf_mkCharLen(p, (int) (sep - p)));
+          SET_STRING_ELT(headers, i, Rf_mkCharLen(sep + 2, (int) (eol - sep - 2)));
+        } else {
+          SET_STRING_ELT(hdr_names, i, Rf_mkCharLen(p, (int) (eol - p)));
+          SET_STRING_ELT(headers, i, Rf_mkChar(""));
+        }
+        i++;
+      }
+      p = eol + 2;
+    }
+
+    nng_strfree(headers_str);
+  }
+
+  UNPROTECT(1);
+  return request;
+
+}
+
 static SEXP make_request_list(nng_http_req *req) {
 
   const char *names[] = {"method", "uri", "headers", "body", ""};
@@ -536,10 +590,11 @@ static void ws_invoke_onopen(void *arg) {
   UNPROTECT(1);
 
   if (info->on_open != R_NilValue) {
-    SEXP call;
-    PROTECT(call = Rf_lang2(info->on_open, ws->conn.xptr));
+    SEXP request, call;
+    PROTECT(request = make_ws_request_list(ws->stream));
+    PROTECT(call = Rf_lang3(info->on_open, ws->conn.xptr, request));
     R_tryEval(call, R_GlobalEnv, NULL);
-    UNPROTECT(1);
+    UNPROTECT(2);
   }
 
   // on_open callback may have closed connection e.g. if not authorized

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -1010,6 +1010,7 @@ if (later && NOT_CRAN) {
 if (later && NOT_CRAN) {
   msgs <- list()
   ws_conn <- NULL
+  ws_req <- NULL
   test_class("nanoServer", srv <- http_server(
     url = "http://127.0.0.1:0",
     handlers = list(
@@ -1020,14 +1021,15 @@ if (later && NOT_CRAN) {
           msgs <<- c(msgs, list(data))
           ws$send(data)
         },
-        on_open = function(ws) {
+        on_open = function(ws, req) {
           ws_conn <<- ws
+          ws_req <<- req
           msgs <<- c(msgs, list("open"))
         },
         on_close = function(ws) { msgs <<- c(msgs, list("close")) },
         textframes = TRUE
       ),
-      handler_ws("/ws-reject", function(ws, data) ws$send(data), on_open = function(ws) ws$close())
+      handler_ws("/ws-reject", function(ws, data) ws$send(data), on_open = function(ws, req) ws$close())
     )
   ))
   test_zero(srv$start())
@@ -1047,6 +1049,10 @@ if (later && NOT_CRAN) {
     test_type("closure", ws_conn$send)
     test_type("closure", ws_conn$close)
     test_null(ws_conn$nonexistent)
+    test_type("list", ws_req)
+    test_equal(ws_req$uri, "/ws")
+    test_type("character", ws_req$headers)
+    test_false(is.null(names(ws_req$headers)))
     test_zero(send(ws, "hello", block = 500))
     while (length(msgs) < 2L) later::run_now(1)
     reply <- recv(ws, block = 500, mode = "character")
@@ -1101,7 +1107,7 @@ if (later && NOT_CRAN) {
           wss_msgs <<- c(wss_msgs, list(data))
           ws$send(paste0("wss:", data))
         },
-        on_open = function(ws) { wss_msgs <<- c(wss_msgs, list("wss_open")) },
+        on_open = function(ws, req) { wss_msgs <<- c(wss_msgs, list("wss_open")) },
         on_close = function(ws) { wss_msgs <<- c(wss_msgs, list("wss_close")) },
         textframes = TRUE
       )
@@ -1146,7 +1152,7 @@ if (later && NOT_CRAN) {
       handler_ws("/upper", function(ws, data) {
         upper_msgs <<- c(upper_msgs, list(data))
         ws$send(toupper(data))
-      }, on_open = function(ws) {
+      }, on_open = function(ws, req) {
         conn_ids <<- c(conn_ids, ws$id)
       }, on_close = function(ws) {
         ws_shutdown_closed <<- ws_shutdown_closed + 1L

--- a/vignettes/v04-web.Rmd
+++ b/vignettes/v04-web.Rmd
@@ -48,7 +48,7 @@ ncurl("https://postman-echo.com/post",
 #> 
 #> $headers
 #> $headers$date
-#> [1] "Sun, 08 Feb 2026 11:22:45 GMT"
+#> [1] "Wed, 25 Feb 2026 20:10:29 GMT"
 #> 
 #> 
 #> $data
@@ -66,7 +66,7 @@ ncurl("https://postman-echo.com/get",
 #> 
 #> $headers
 #> $headers$Date
-#> [1] "Sun, 08 Feb 2026 11:22:45 GMT"
+#> [1] "Wed, 25 Feb 2026 20:10:30 GMT"
 #> 
 #> $headers$`Content-Type`
 #> [1] "application/json; charset=utf-8"
@@ -78,7 +78,7 @@ ncurl("https://postman-echo.com/get",
 #> [1] "close"
 #> 
 #> $headers$`CF-RAY`
-#> [1] "9caac0420a1dc16b-LHR"
+#> [1] "9d39d8b0eb7bce7b-LHR"
 #> 
 #> $headers$etag
 #> [1] "W/\"8f-7zN8nSad8A9WlFJjKQZB04z5nHE\""
@@ -87,10 +87,10 @@ ncurl("https://postman-echo.com/get",
 #> [1] "Accept-Encoding"
 #> 
 #> $headers$`Set-Cookie`
-#> [1] "sails.sid=s%3A3tYl-iuzp8jF0j82bxVHtxrx87HF8PoG.ykEiyyCKGOB1tWjbdRBXQQN7R2JwAHxl%2FkpAWvaV%2FIs; Path=/; HttpOnly, __cf_bm=xmba.Nkum1545BuZtIF1AkAAJzxI0VLZrdSg2QarH6M-1770549765-1.0.1.1-Twtq9B6vpPFSSJbuRQ9AaEDUB83Sprl4keRU_kvVk7PZqFGUZc1cVqFvyfN14NRX1CG5qT1idcqkSWejx03q6v3KYkPgCga6vJiifoRoVUs; path=/; expires=Sun, 08-Feb-26 11:52:45 GMT; domain=.postman-echo.com; HttpOnly; Secure, _cfuvid=u2FHSl3lIzG1PMEmFIe9J58inYS1BQ8KH5f7Y3RV1Nk-1770549765548-0.0.1.1-604800000; path=/; domain=.postman-echo.com; HttpOnly; Secure; SameSite=None"
+#> [1] "sails.sid=s%3AwH622ngshSXMrA7ebK36VF8ljdvJURS_.dc0udVn4RC4LtE%2BuLRsSPSguz4JiRmp2ko1ecmMaxWI; Path=/; HttpOnly, __cf_bm=sijEg6f0LkDsu4.vo_d65ThwUaephl5UJTmhqTqHOxQ-1772050230-1.0.1.1-_7tgVpEYqMqBiaCocz16tASo_t.71RsyJlO74Q_tW33JvUS8gP0H.n0XYNVQ6IWXf9bHQEE2ClHqnRCDrReRcrgzZcYD.im_JDYn_fB6O1g; path=/; expires=Wed, 25-Feb-26 20:40:30 GMT; domain=.postman-echo.com; HttpOnly; Secure, _cfuvid=yjuM4wzOZHEA..Tmr5h3VMYGOY6fe8afDDwByo9TcZg-1772050230010-0.0.1.1-604800000; path=/; domain=.postman-echo.com; HttpOnly; Secure; SameSite=None"
 #> 
 #> $headers$`x-envoy-upstream-service-time`
-#> [1] "5"
+#> [1] "4"
 #> 
 #> $headers$`cf-cache-status`
 #> [1] "DYNAMIC"
@@ -119,7 +119,7 @@ res
 
 call_aio(res)$headers
 #> $date
-#> [1] "Sun, 08 Feb 2026 11:22:45 GMT"
+#> [1] "Wed, 25 Feb 2026 20:10:30 GMT"
 
 res$status
 #> [1] 200
@@ -160,20 +160,21 @@ transact(sess)
 #> 
 #> $headers
 #> $headers$Date
-#> [1] "Sun, 08 Feb 2026 11:22:46 GMT"
+#> [1] "Wed, 25 Feb 2026 20:10:30 GMT"
 #> 
 #> $headers$`Content-Type`
 #> [1] "application/json; charset=utf-8"
 #> 
 #> 
 #> $data
-#>   [1] 7b 22 61 72 67 73 22 3a 7b 7d 2c 22 68 65 61 64 65 72 73 22 3a 7b 22 68 6f 73 74 22 3a
-#>  [30] 22 70 6f 73 74 6d 61 6e 2d 65 63 68 6f 2e 63 6f 6d 22 2c 22 61 63 63 65 70 74 2d 65 6e
-#>  [59] 63 6f 64 69 6e 67 22 3a 22 67 7a 69 70 2c 20 62 72 22 2c 22 78 2d 66 6f 72 77 61 72 64
-#>  [88] 65 64 2d 70 72 6f 74 6f 22 3a 22 68 74 74 70 73 22 2c 22 63 6f 6e 74 65 6e 74 2d 74 79
-#> [117] 70 65 22 3a 22 61 70 70 6c 69 63 61 74 69 6f 6e 2f 6a 73 6f 6e 22 7d 2c 22 75 72 6c 22
-#> [146] 3a 22 68 74 74 70 73 3a 2f 2f 70 6f 73 74 6d 61 6e 2d 65 63 68 6f 2e 63 6f 6d 2f 67 65
-#> [175] 74 22 7d
+#>   [1] 7b 22 61 72 67 73 22 3a 7b 7d 2c 22 68 65 61 64 65 72 73 22 3a 7b 22 68 6f
+#>  [26] 73 74 22 3a 22 70 6f 73 74 6d 61 6e 2d 65 63 68 6f 2e 63 6f 6d 22 2c 22 61
+#>  [51] 63 63 65 70 74 2d 65 6e 63 6f 64 69 6e 67 22 3a 22 67 7a 69 70 2c 20 62 72
+#>  [76] 22 2c 22 78 2d 66 6f 72 77 61 72 64 65 64 2d 70 72 6f 74 6f 22 3a 22 68 74
+#> [101] 74 70 73 22 2c 22 63 6f 6e 74 65 6e 74 2d 74 79 70 65 22 3a 22 61 70 70 6c
+#> [126] 69 63 61 74 69 6f 6e 2f 6a 73 6f 6e 22 7d 2c 22 75 72 6c 22 3a 22 68 74 74
+#> [151] 70 73 3a 2f 2f 70 6f 73 74 6d 61 6e 2d 65 63 68 6f 2e 63 6f 6d 2f 67 65 74
+#> [176] 22 7d
 
 close(sess)
 
@@ -330,7 +331,7 @@ server <- http_server(
         # Broadcast to all connected clients
         for (client in clients) client$send(data)
       },
-      on_open = function(ws) {
+      on_open = function(ws, req) {
         clients[[as.character(ws$id)]] <<- ws
       },
       on_close = function(ws) {
@@ -466,7 +467,7 @@ server <- http_server(
 server$start()
 server
 #> < nanoServer >
-#>  - url: https://127.0.0.1:50715 
+#>  - url: https://127.0.0.1:50424 
 #>  - state: started
 
 # HTTPS client request


### PR DESCRIPTION
The `on_open` callback for `handler_ws()` now receives a second argument `req`.

This is a list with `uri` (character) and `headers` (named character vector) from the HTTP upgrade request. This enables auth workflows (e.g. inspecting Authorization or cookie headers) and path-based routing in `on_open`. 