### PR TITLE
Dispatcher efficiency and struct layout optimization

### DIFF
--- a/src/dispatcher.c
+++ b/src/dispatcher.c
@@ -150,17 +150,6 @@ static void dispatch_insert_daemon(nano_dispatcher *d, int pipe) {
 
 }
 
-static void dispatch_remove_daemon(nano_dispatcher *d, int pipe) {
-
-  for (int i = 0; i < d->outq_count; i++) {
-    if (d->daemons[i].pipe == pipe) {
-      d->daemons[i] = d->daemons[--d->outq_count];
-      return;
-    }
-  }
-
-}
-
 // queue operations ------------------------------------------------------------
 
 static void dispatch_enqueue(nano_dispatcher *d, nng_ctx ctx,
@@ -399,8 +388,7 @@ static void dispatch_handle_connect(nano_dispatcher *d, int pipe) {
   unsigned char *buf = nng_msg_body(msg);
   memcpy(buf, d->init_template, d->init_template_len);
 
-  for (int i = 0; i < 6; i++)
-    memcpy(buf + d->init_seed_offset + i * 4, &d->rng_seed[i], sizeof(int));
+  memcpy(buf + d->init_seed_offset, d->rng_seed, sizeof(d->rng_seed));
 
   if (dispatch_send_msg_to_daemon(d, pipe, msg) != 0)
     nng_msg_free(msg);
@@ -433,7 +421,7 @@ static void dispatch_handle_disconnect(nano_dispatcher *d, int pipe) {
     ctx = dd->ctx;
   }
 
-  dispatch_remove_daemon(d, pipe);
+  *dd = d->daemons[--d->outq_count];
   nng_mtx_unlock(d->cv->mtx);
 
   if (busy) {
@@ -531,14 +519,13 @@ static void dispatch_handle_daemon_recv(nano_dispatcher *d) {
   nng_msg *msg = nng_aio_get_msg(d->daemon_aio);
   nng_pipe pipe = nng_msg_get_pipe(msg);
   int pipe_id = (int) pipe.id;
-  int is_marker = 0;
+  int dummy, is_marker;
+  dispatch_read_msg_info(nng_msg_body(msg), nng_msg_len(msg), &dummy, &is_marker);
 
   nng_mtx_lock(d->cv->mtx);
   nano_dispatch_daemon *dd = dispatch_find_daemon(d, pipe_id);
   if (dd != NULL && dd->msgid != 0) {
     d->executing--;
-    int dummy;
-    dispatch_read_msg_info(nng_msg_body(msg), nng_msg_len(msg), &dummy, &is_marker);
     nng_ctx ctx = dd->ctx;
 
     if (d->limit > 0) {
@@ -547,7 +534,7 @@ static void dispatch_handle_daemon_recv(nano_dispatcher *d) {
     }
 
     if (is_marker) {
-      dispatch_remove_daemon(d, pipe_id);
+      *dd = d->daemons[--d->outq_count];
     } else {
       dd->msgid = 0;
     }

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -192,8 +192,8 @@ typedef struct nano_aio_s {
   void *cb;
   void *next;
   int result;
-  uint8_t mode;
   nano_aio_typ type;
+  uint8_t mode;
 } nano_aio;
 
 typedef struct nano_saio_s {
@@ -275,14 +275,14 @@ typedef enum {
 
 // Base connection structure - common fields for linked list and lifecycle
 typedef struct nano_conn_s {
-  nano_conn_type type;              // Connection type (for dispatch)
   nng_aio *send_aio;                // For async send (both types)
   nano_http_handler_info *handler;  // Back-reference to handler
   struct nano_conn_s *next;         // Linked list
   struct nano_conn_s *prev;         // Doubly-linked for O(1) removal
   SEXP xptr;                        // R external pointer
-  int id;                           // Unique connection ID (server-wide)
+  nano_conn_type type;              // Connection type (for dispatch)
   nano_conn_state state;            // Connection state
+  int id;                           // Unique connection ID (server-wide)
   int onclose_scheduled;            // Prevents duplicate on_close callbacks
 } nano_conn;
 
@@ -332,22 +332,22 @@ typedef struct nano_http_request_s {
 } nano_http_request;
 
 typedef enum {
-  SERVER_CREATED,   // Server created but not started
-  SERVER_STARTED,   // Server running
-  SERVER_STOPPED    // Server stopped
+  SERVER_CREATED,
+  SERVER_STARTED,
+  SERVER_STOPPED
 } nano_server_state;
 
 typedef struct nano_http_server_s {
   nng_http_server *server;          // NNG HTTP server
   nng_tls_config *tls;              // TLS configuration
   nano_http_handler_info *handlers; // Array of handler info
-  int handler_count;                // Number of handlers
   nano_http_request *pending_reqs;  // Linked list of pending HTTP requests
   nng_mtx *mtx;                     // Mutex for thread safety
-  int conn_counter;                 // Server-wide unique connection ID counter
-  nano_server_state state;          // Server lifecycle state
   SEXP xptr;                        // R external pointer for this server
   SEXP prot;                        // Pairlist for GC protection of callbacks
+  int handler_count;                // Number of handlers
+  int conn_counter;                 // Server-wide unique connection ID counter
+  nano_server_state state;          // Server lifecycle state
 } nano_http_server;
 
 typedef struct ws_message_s {


### PR DESCRIPTION
Dispatcher hot path:                                                      
- Eliminate redundant O(n) daemon array scans on disconnect and marker response — remove by pointer directly instead of re-scanning after `dispatch_find_daemon()`
- Move message parsing outside mutex in `dispatch_handle_daemon_recv()` to reduce critical section
- Single memcpy for RNG seed injection instead of loop of 6 individual copies
                                                                            
Struct layouts: 
- Reorder fields to eliminate internal padding holes in `nano_conn` (cascades to `nano_ws_conn` and `nano_stream_conn`), `nano_http_server` and `nano_aio`