### PR TITLE
Fix strtoul truncation of refhook payload size on 64-bit Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Serialized send operations now transfer the buffer directly into the NNG message, eliminating a redundant copy and halving peak memory usage (#219).
 * Fixes sending and receiving of messages larger than `INT_MAX` bytes over TCP and IPC transports on macOS and Windows (#266).
+* Fixes unserialization of custom refhook payloads larger than `ULONG_MAX` on 64-bit Windows.
 * Removes `messenger()` as a non-core function (#268).
 * Removes the deprecated `n` argument from `recv()` and `recv_aio()`.
 * Minimum required NNG version raised to 1.11 (bundled: 1.11.1-pre).

--- a/src/core.c
+++ b/src/core.c
@@ -154,7 +154,7 @@ static SEXP nano_unserialize_hook(SEXP x, SEXP hook_func) {
   void (*InBytes)(R_inpstream_t, void *, int) = stream->InBytes;
 
   const char *size_string = NANO_STRING(x);
-  uint64_t size = strtoul(size_string, NULL, 10);
+  uint64_t size = strtoull(size_string, NULL, 10);
 
   SEXP raw, call, out;
   PROTECT(raw = Rf_allocVector(RAWSXP, size));


### PR DESCRIPTION
`strtoul` returns unsigned long — 32-bit on Windows LLP64. `strtoull` returns unsigned long long — 64-bit everywhere.