### PR TITLE
Fix: potential size_t overflow in iov clamping check

### DIFF
--- a/src/nng/src/platform/posix/posix_ipcconn.c
+++ b/src/nng/src/platform/posix/posix_ipcconn.c
@@ -62,7 +62,7 @@ ipc_dowrite(ipc_conn *c)
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
 				size_t len = aiov[i].iov_len;
-				if (count + len > INT_MAX)
+				if (len > INT_MAX - count)
 					len = INT_MAX - count;
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
@@ -129,7 +129,7 @@ ipc_doread(ipc_conn *c)
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
 				size_t len = aiov[i].iov_len;
-				if (count + len > INT_MAX)
+				if (len > INT_MAX - count)
 					len = INT_MAX - count;
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;

--- a/src/nng/src/platform/posix/posix_tcpconn.c
+++ b/src/nng/src/platform/posix/posix_tcpconn.c
@@ -61,7 +61,7 @@ tcp_dowrite(nni_tcp_conn *c)
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
 				size_t len = aiov[i].iov_len;
-				if (count + len > INT_MAX)
+				if (len > INT_MAX - count)
 					len = INT_MAX - count;
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
@@ -128,7 +128,7 @@ tcp_doread(nni_tcp_conn *c)
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
 				size_t len = aiov[i].iov_len;
-				if (count + len > INT_MAX)
+				if (len > INT_MAX - count)
 					len = INT_MAX - count;
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;

--- a/src/nng/src/platform/windows/win_tcpconn.c
+++ b/src/nng/src/platform/windows/win_tcpconn.c
@@ -44,7 +44,7 @@ tcp_recv_start(nni_tcp_conn *c)
 	  for (niov = 0, i = 0; i < naiov; i++) {
 	    if (aiov[i].iov_len != 0) {
 	      size_t len = aiov[i].iov_len;
-	      if (count + len > INT_MAX)
+	      if (len > INT_MAX - count)
 	        len = INT_MAX - count;
 	      iov[niov].buf = aiov[i].iov_buf;
 	      iov[niov].len = (ULONG) len;
@@ -164,7 +164,7 @@ tcp_send_start(nni_tcp_conn *c)
 	  for (niov = 0, i = 0; i < naiov; i++) {
 	    if (aiov[i].iov_len != 0) {
 	      size_t len = aiov[i].iov_len;
-	      if (count + len > INT_MAX)
+	      if (len > INT_MAX - count)
 	        len = INT_MAX - count;
 	      iov[niov].buf = aiov[i].iov_buf;
 	      iov[niov].len = (ULONG) len;


### PR DESCRIPTION
Amends #267.

`count + len > INT_MAX` can overflow if `count + len > SIZE_MAX` on 32-bit platforms. Rearranging to `len > INT_MAX - count` avoids the overflow since `count` never exceeds `INT_MAX`.