### PR TITLE
Free NNG receive buffer eagerly after decode

### DIFF
--- a/src/aio.c
+++ b/src/aio.c
@@ -232,13 +232,17 @@ static inline SEXP create_aio_msg(SEXP env, SEXP aio, nano_aio *raio, int res) {
   if (raio->type == IOV_RECVAIO || raio->type == IOV_RECVAIOS) {
     buf = raio->data;
     sz = nng_aio_count(raio->aio);
+    PROTECT(out = nano_decode(buf, sz, raio->mode, NANO_PROT(aio)));
+    free(raio->data);
   } else {
     nng_msg *msg = (nng_msg *) raio->data;
     buf = nng_msg_body(msg);
     sz = nng_msg_len(msg);
+    PROTECT(out = nano_decode(buf, sz, raio->mode, NANO_PROT(aio)));
+    nng_msg_free(msg);
   }
+  raio->data = NULL;
 
-  PROTECT(out = nano_decode(buf, sz, raio->mode, NANO_PROT(aio)));
   PROTECT(pipe = Rf_ScalarInteger(-res));
   Rf_defineVar(nano_ValueSymbol, out, env);
   Rf_defineVar(nano_AioSymbol, pipe, env);


### PR DESCRIPTION
## Summary

- Free NNG receive buffer in `create_aio_msg()` immediately after `nano_decode()` copies data into the R object, rather than deferring to the external pointer finalizer

## Rationale

After `nano_decode()` copies received data into a new R SEXP, the source NNG buffer (either `malloc`'d for IOV receives or an `nng_msg` for message receives) is no longer needed. Previously it was freed only when R's garbage collector ran the aio's finalizer.

R's GC is pressure-driven but only tracks R heap allocations — it has no visibility into external `malloc`'d or NNG-allocated memory. Between GC cycles, stale NNG buffers from resolved aios accumulate as invisible external memory. Eager freeing makes cleanup deterministic and prevents this accumulation, particularly when resolving many aios in quick succession.

Setting `raio->data = NULL` after freeing is safe because both `iaio_finalizer` and `raio_finalizer` already guard with `if (xp->data != NULL)`.