### PR TITLE
Fix internal `rnng_dispatcher_wait()`

### DIFF
--- a/src/dispatcher.c
+++ b/src/dispatcher.c
@@ -1077,7 +1077,7 @@ SEXP rnng_dispatcher_wait(SEXP disp, SEXP n) {
   nng_mtx *mtx = d->cv->mtx;
 
   nng_mtx_lock(mtx);
-  while (d->connections < target && d->cv->flag >= 0) {
+  while (d->outq_count < target && d->cv->flag >= 0) {
     nng_time time = nng_clock() + 400;
     nng_cv_until(cv, time);
     nng_mtx_unlock(mtx);


### PR DESCRIPTION
Wait for active connections, not cumulative count.