### PR TITLE
Refactor internal R API accessors

### DIFF
--- a/src/aio.c
+++ b/src/aio.c
@@ -397,7 +397,7 @@ SEXP rnng_aio_call(SEXP x) {
   case VECSXP: {
     const R_xlen_t xlen = Rf_xlength(x);
     for (R_xlen_t i = 0; i < xlen; i++) {
-      rnng_aio_call(NANO_VECTOR(x)[i]);
+      rnng_aio_call(VECTOR_PTR_RO(x)[i]);
     }
     break;
   }
@@ -423,7 +423,7 @@ static SEXP rnng_aio_collect_impl(SEXP x, SEXP (*const func)(SEXP)) {
     const R_xlen_t xlen = Rf_xlength(x);
     PROTECT(out = Rf_allocVector(VECSXP, xlen));
     for (R_xlen_t i = 0; i < xlen; i++) {
-      env = func(NANO_VECTOR(x)[i]);
+      env = func(VECTOR_PTR_RO(x)[i]);
       if (TYPEOF(env) != ENVSXP) goto fail;
       val = nano_findVarInFrame(env, nano_ValueSymbol, &found);
       if (!found) goto fail;
@@ -478,7 +478,7 @@ SEXP rnng_aio_stop(SEXP x) {
   case VECSXP: {
     const R_xlen_t xlen = Rf_xlength(x);
     for (R_xlen_t i = 0; i < xlen; i++) {
-      rnng_aio_stop(NANO_VECTOR(x)[i]);
+      rnng_aio_stop(VECTOR_PTR_RO(x)[i]);
     }
     break;
   }
@@ -535,7 +535,7 @@ SEXP rnng_request_stop(SEXP x) {
     const R_xlen_t xlen = Rf_xlength(x);
     PROTECT(out = Rf_allocVector(LGLSXP, xlen));
     for (R_xlen_t i = xlen - 1; i >= 0; i--) {
-      SEXP item = rnng_request_stop(NANO_VECTOR(x)[i]);
+      SEXP item = rnng_request_stop(VECTOR_PTR_RO(x)[i]);
       SET_LOGICAL_ELT(out, i, NANO_INTEGER(item));
     }
     UNPROTECT(1);
@@ -595,7 +595,7 @@ SEXP rnng_unresolved(SEXP x) {
   case VECSXP: {
     const R_xlen_t xlen = Rf_xlength(x);
     for (R_xlen_t i = 0; i < xlen; i++) {
-      if (rnng_unresolved_impl(NANO_VECTOR(x)[i]))
+      if (rnng_unresolved_impl(VECTOR_PTR_RO(x)[i]))
         return Rf_ScalarLogical(1);
     }
   }
@@ -628,7 +628,7 @@ SEXP rnng_unresolved2(SEXP x) {
     int xc = 0;
     const R_xlen_t xlen = Rf_xlength(x);
     for (R_xlen_t i = 0; i < xlen; i++) {
-      xc += rnng_unresolved2_impl(NANO_VECTOR(x)[i]);
+      xc += rnng_unresolved2_impl(VECTOR_PTR_RO(x)[i]);
     }
     return Rf_ScalarInteger(xc);
   }
@@ -640,7 +640,7 @@ SEXP rnng_unresolved2(SEXP x) {
 
 static inline R_xlen_t race_find_resolved(SEXP x, R_xlen_t xlen) {
   for (R_xlen_t i = 0; i < xlen; i++) {
-    SEXP elem = NANO_VECTOR(x)[i];
+    SEXP elem = VECTOR_PTR_RO(x)[i];
     if (TYPEOF(elem) == ENVSXP && !rnng_unresolved2_impl(elem))
       return i + 1;
   }
@@ -650,7 +650,7 @@ static inline R_xlen_t race_find_resolved(SEXP x, R_xlen_t xlen) {
 static inline int race_count_unresolved(SEXP x, R_xlen_t xlen) {
   int n = 0;
   for (R_xlen_t i = 0; i < xlen; i++)
-    n += rnng_unresolved2_impl(NANO_VECTOR(x)[i]);
+    n += rnng_unresolved2_impl(VECTOR_PTR_RO(x)[i]);
   return n;
 }
 

--- a/src/core.c
+++ b/src/core.c
@@ -95,9 +95,10 @@ static SEXP nano_serialize_hook(SEXP x, SEXP hook_func) {
 
   SEXP klass = nano_bundle.klass;
   int len = (int) XLENGTH(klass), match = 0, i;
+  const SEXP *klass_p = STRING_PTR_RO(klass);
 
   for (i = 0; i < len; i++) {
-    if (Rf_inherits(x, NANO_STR_N(klass, i))) {
+    if (Rf_inherits(x, CHAR(klass_p[i]))) {
       match = 1;
       break;
     }
@@ -110,12 +111,12 @@ static SEXP nano_serialize_hook(SEXP x, SEXP hook_func) {
   void (*OutBytes)(R_outpstream_t, void *, int) = stream->OutBytes;
 
   SEXP out, call;
-  PROTECT(call = Rf_lcons(NANO_VECTOR(hook_func)[i], Rf_cons(x, R_NilValue)));
+  PROTECT(call = Rf_lcons(VECTOR_PTR_RO(hook_func)[i], Rf_cons(x, R_NilValue)));
   out = R_UnwindProtect(nano_eval_prot, call, nano_cleanup, stream->data, NULL);
   UNPROTECT(1);
   if (TYPEOF(out) != RAWSXP) {
     free(((nano_buf *) stream->data)->buf);
-    Rf_error("Serialization function for `%s` did not return a raw vector", NANO_STR_N(klass, i));
+    Rf_error("Serialization function for `%s` did not return a raw vector", CHAR(klass_p[i]));
   }
 
   uint64_t size = XLENGTH(out);
@@ -153,7 +154,7 @@ static SEXP nano_unserialize_hook(SEXP x, SEXP hook_func) {
   R_inpstream_t stream = nano_bundle.inpstream;
   void (*InBytes)(R_inpstream_t, void *, int) = stream->InBytes;
 
-  const char *size_string = NANO_STRING(x);
+  const char *size_string = CHAR(STRING_ELT(x, 0));
   uint64_t size = strtoull(size_string, NULL, 10);
 
   SEXP raw, call, out;
@@ -172,7 +173,7 @@ static SEXP nano_unserialize_hook(SEXP x, SEXP hook_func) {
   char buf[20];
   InBytes(stream, buf, 20);
 
-  PROTECT(call = Rf_lcons(NANO_VECTOR(hook_func)[i], Rf_cons(raw, R_NilValue)));
+  PROTECT(call = Rf_lcons(VECTOR_PTR_RO(hook_func)[i], Rf_cons(raw, R_NilValue)));
   out = Rf_eval(call, R_GlobalEnv);
 
   UNPROTECT(2);
@@ -316,7 +317,7 @@ void nano_serialize(nano_buf *buf, SEXP object, SEXP hook, int header) {
   }
 
   if (hook != R_NilValue) {
-    nano_bundle.klass = NANO_VECTOR(hook)[0];
+    nano_bundle.klass = VECTOR_PTR_RO(hook)[0];
     nano_bundle.outpstream = &output_stream;
   }
 
@@ -328,7 +329,7 @@ void nano_serialize(nano_buf *buf, SEXP object, SEXP hook, int header) {
     NULL,
     nano_write_bytes,
     hook != R_NilValue ? nano_serialize_hook : NULL,
-    hook != R_NilValue ? NANO_VECTOR(hook)[1] : R_NilValue
+    hook != R_NilValue ? VECTOR_PTR_RO(hook)[1] : R_NilValue
   );
 
   R_Serialize(object, &output_stream);
@@ -391,7 +392,7 @@ SEXP nano_unserialize(unsigned char *buf, size_t sz, SEXP hook) {
     nano_read_char,
     nano_read_bytes,
     hook != R_NilValue ? nano_unserialize_hook : NULL,
-    hook != R_NilValue ? NANO_VECTOR(hook)[2] : R_NilValue
+    hook != R_NilValue ? VECTOR_PTR_RO(hook)[2] : R_NilValue
   );
 
   return R_Unserialize(&input_stream);
@@ -494,17 +495,18 @@ void nano_encode(nano_buf *enc, const SEXP object) {
     const char *s;
     R_xlen_t xlen = XLENGTH(object);
     if (xlen == 1) {
-      s = NANO_STRING(object);
+      s = CHAR(STRING_ELT(object, 0));
       NANO_INIT(enc, (unsigned char *) s, strlen(s) + 1);
       break;
     }
     R_xlen_t i;
     size_t slen, outlen = 0;
+    const SEXP *object_p = STRING_PTR_RO(object);
     for (i = 0; i < xlen; i++)
-      outlen += strlen(NANO_STR_N(object, i)) + 1;
+      outlen += strlen(CHAR(object_p[i])) + 1;
     NANO_ALLOC(enc, outlen);
     for (i = 0; i < xlen; i++) {
-      s = NANO_STR_N(object, i);
+      s = CHAR(object_p[i]);
       slen = strlen(s) + 1;
       memcpy(enc->buf + enc->cur, s, slen);
       enc->cur += slen;

--- a/src/dispatcher.c
+++ b/src/dispatcher.c
@@ -954,7 +954,7 @@ SEXP rnng_dispatcher_start(SEXP url, SEXP disp_url, SEXP tls,
     goto fail;
 
   // Listen for daemon connections
-  const char *url_str = NANO_STRING(url);
+  const char *url_str = CHAR(STRING_ELT(url, 0));
   if (TYPEOF(tls) != NILSXP && !NANO_PTR_CHECK(tls, nano_TlsSymbol)) {
     nng_tls_config *cfg = (nng_tls_config *) NANO_PTR(tls);
     if ((xc = nng_listener_create(&listener, h->poly_sock, url_str)) ||
@@ -971,7 +971,7 @@ SEXP rnng_dispatcher_start(SEXP url, SEXP disp_url, SEXP tls,
     goto fail;
   d->rep_sock = &h->rep_sock;
 
-  const char *disp_url_str = NANO_STRING(disp_url);
+  const char *disp_url_str = CHAR(STRING_ELT(disp_url, 0));
   if ((xc = nng_dial(h->rep_sock, disp_url_str, NULL, 0)))
     goto fail;
 

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -120,7 +120,7 @@ extern int R_interrupts_pending;
 #if R_VERSION < R_Version(4, 5, 0)
 # define VECTOR_PTR_RO(x) ((const SEXP *) DATAPTR_RO(x))
 #endif
-#define NANO_INTEGER(x) *(int *) DATAPTR_RO(x)
+#define NANO_INTEGER(x) *(const int *) DATAPTR_RO(x)
 
 #define ERROR_OUT(xc) Rf_error("%d | %s", xc, nng_strerror(xc))
 #define ERROR_RET(xc) { Rf_warning("%d | %s", xc, nng_strerror(xc)); return mk_error(xc); }

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -117,9 +117,9 @@ extern int R_interrupts_pending;
 #define NANO_SET_PROT(x, v) SETCDR(x, v)
 #define NANO_SET_ENCLOS(x, v) SETCDR(x, v)
 #define NANO_DATAPTR(x) (void *) DATAPTR_RO(x)
-#define NANO_VECTOR(x) ((const SEXP *) DATAPTR_RO(x))
-#define NANO_STRING(x) CHAR(*((const SEXP *) DATAPTR_RO(x)))
-#define NANO_STR_N(x, n) CHAR(((const SEXP *) DATAPTR_RO(x))[n])
+#if R_VERSION < R_Version(4, 5, 0)
+# define VECTOR_PTR_RO(x) ((const SEXP *) DATAPTR_RO(x))
+#endif
 #define NANO_INTEGER(x) *(int *) DATAPTR_RO(x)
 
 #define ERROR_OUT(xc) Rf_error("%d | %s", xc, nng_strerror(xc))

--- a/src/ncurl.c
+++ b/src/ncurl.c
@@ -84,7 +84,7 @@ static nano_buf nano_char_buf(const SEXP data) {
   nano_buf buf = {0};
   switch (TYPEOF(data)) {
   case STRSXP: {
-    const char *s = NANO_STRING(data);
+    const char *s = CHAR(STRING_ELT(data, 0));
     NANO_INIT(&buf, (unsigned char *) s, strlen(s));
     break;
   }
@@ -192,8 +192,9 @@ static inline SEXP create_aio_http(SEXP env, nano_aio *haio, int typ) {
       const R_xlen_t rlen = XLENGTH(response);
       PROTECT(rvec = Rf_allocVector(VECSXP, rlen));
       Rf_namesgets(rvec, response);
+      const SEXP *response_p = STRING_PTR_RO(response);
       for (R_xlen_t i = 0; i < rlen; i++) {
-        const char *r = nng_http_res_get_header(handle->res, NANO_STR_N(response, i));
+        const char *r = nng_http_res_get_header(handle->res, CHAR(response_p[i]));
         SET_VECTOR_ELT(rvec, i, r == NULL ? R_NilValue : Rf_mkString(r));
       }
       UNPROTECT(1);
@@ -303,8 +304,10 @@ SEXP rnng_ncurl(SEXP http, SEXP convert, SEXP follow, SEXP method, SEXP headers,
     const R_xlen_t hlen = XLENGTH(headers);
     SEXP hnames = Rf_getAttrib(headers, R_NamesSymbol);
     if (TYPEOF(hnames) == STRSXP && XLENGTH(hnames) == hlen) {
+      const SEXP *hnames_p = STRING_PTR_RO(hnames);
+      const SEXP *headers_p = STRING_PTR_RO(headers);
       for (R_xlen_t i = 0; i < hlen; i++) {
-        if ((xc = nng_http_req_set_header(req, NANO_STR_N(hnames, i), NANO_STR_N(headers, i))))
+        if ((xc = nng_http_req_set_header(req, CHAR(hnames_p[i]), CHAR(headers_p[i]))))
           goto fail;
       }
     }
@@ -395,8 +398,9 @@ SEXP rnng_ncurl(SEXP http, SEXP convert, SEXP follow, SEXP method, SEXP headers,
       rvec = Rf_allocVector(VECSXP, rlen);
       SET_VECTOR_ELT(out, 1, rvec);
       Rf_namesgets(rvec, response);
+      const SEXP *response_p = STRING_PTR_RO(response);
       for (R_xlen_t i = 0; i < rlen; i++) {
-        const char *r = nng_http_res_get_header(res, NANO_STR_N(response, i));
+        const char *r = nng_http_res_get_header(res, CHAR(response_p[i]));
         SET_VECTOR_ELT(rvec, i, r == NULL ? R_NilValue : Rf_mkString(r));
       }
     } else {
@@ -478,8 +482,10 @@ SEXP rnng_ncurl_aio(SEXP http, SEXP convert, SEXP method, SEXP headers, SEXP dat
     const R_xlen_t hlen = XLENGTH(headers);
     SEXP hnames = Rf_getAttrib(headers, R_NamesSymbol);
     if (TYPEOF(hnames) == STRSXP && XLENGTH(hnames) == hlen) {
+      const SEXP *hnames_p = STRING_PTR_RO(hnames);
+      const SEXP *headers_p = STRING_PTR_RO(headers);
       for (R_xlen_t i = 0; i < hlen; i++) {
-        if ((xc = nng_http_req_set_header(handle->req, NANO_STR_N(hnames, i), NANO_STR_N(headers, i))))
+        if ((xc = nng_http_req_set_header(handle->req, CHAR(hnames_p[i]), CHAR(headers_p[i]))))
           goto fail;
       }
     }
@@ -603,8 +609,10 @@ SEXP rnng_ncurl_session(SEXP http, SEXP convert, SEXP method, SEXP headers, SEXP
     const R_xlen_t hlen = XLENGTH(headers);
     SEXP hnames = Rf_getAttrib(headers, R_NamesSymbol);
     if (TYPEOF(hnames) == STRSXP && XLENGTH(hnames) == hlen) {
+      const SEXP *hnames_p = STRING_PTR_RO(hnames);
+      const SEXP *headers_p = STRING_PTR_RO(headers);
       for (R_xlen_t i = 0; i < hlen; i++) {
-        if ((xc = nng_http_req_set_header(handle->req, NANO_STR_N(hnames, i), NANO_STR_N(headers, i))))
+        if ((xc = nng_http_req_set_header(handle->req, CHAR(hnames_p[i]), CHAR(headers_p[i]))))
           goto fail;
       }
     }
@@ -708,8 +716,9 @@ SEXP rnng_ncurl_transact(SEXP session) {
     rvec = Rf_allocVector(VECSXP, rlen);
     SET_VECTOR_ELT(out, 1, rvec);
     Rf_namesgets(rvec, response);
+    const SEXP *response_p = STRING_PTR_RO(response);
     for (R_xlen_t i = 0; i < rlen; i++) {
-      const char *r = nng_http_res_get_header(handle->res, NANO_STR_N(response, i));
+      const char *r = nng_http_res_get_header(handle->res, CHAR(response_p[i]));
       SET_VECTOR_ELT(rvec, i, r == NULL ? R_NilValue : Rf_mkString(r));
     }
   } else {

--- a/src/proto.c
+++ b/src/proto.c
@@ -229,11 +229,13 @@ static SEXP nano_stream_dial(SEXP url, SEXP textframes, SEXP headers, SEXP tls, 
       const R_xlen_t hlen = XLENGTH(headers);
       SEXP hnames = Rf_getAttrib(headers, R_NamesSymbol);
       if (TYPEOF(hnames) == STRSXP && XLENGTH(hnames) == hlen) {
+        const SEXP *hnames_p = STRING_PTR_RO(hnames);
+        const SEXP *headers_p = STRING_PTR_RO(headers);
         for (R_xlen_t i = 0; i < hlen; i++) {
-          const char *name = NANO_STR_N(hnames, i);
+          const char *name = CHAR(hnames_p[i]);
           char optname[256];
           snprintf(optname, sizeof(optname), "%s%s", NNG_OPT_WS_REQUEST_HEADER, name);
-          if ((xc = nng_stream_dialer_set_string(nst->endpoint.dial, optname, NANO_STR_N(headers, i))))
+          if ((xc = nng_stream_dialer_set_string(nst->endpoint.dial, optname, CHAR(headers_p[i]))))
             goto fail;
         }
       }

--- a/src/server.c
+++ b/src/server.c
@@ -29,7 +29,7 @@
     (len) = (size_t) XLENGTH(data); \
     break; \
   case STRSXP: \
-    (buf) = (unsigned char *) NANO_STRING(data); \
+    (buf) = (unsigned char *) CHAR(STRING_ELT(data, 0)); \
     (len) = strlen((const char *) (buf)); \
     break; \
   default: \
@@ -374,10 +374,10 @@ static void http_invoke_callback(void *arg) {
       PROTECT(res_headers);
       SEXP hdr_nm = Rf_getAttrib(res_headers, R_NamesSymbol);
       if (TYPEOF(hdr_nm) == STRSXP) {
+        const SEXP *hdr_nm_p = STRING_PTR_RO(hdr_nm);
+        const SEXP *res_headers_p = STRING_PTR_RO(res_headers);
         for (int i = 0; i < XLENGTH(res_headers); i++) {
-          const char *name = NANO_STR_N(hdr_nm, i);
-          const char *value = NANO_STR_N(res_headers, i);
-          nng_http_res_set_header(res, name, value);
+          nng_http_res_set_header(res, CHAR(hdr_nm_p[i]), CHAR(res_headers_p[i]));
         }
       }
       UNPROTECT(1);
@@ -853,7 +853,7 @@ SEXP rnng_http_server_create(SEXP url, SEXP handlers, SEXP tls) {
 
         switch (TYPEOF(data_elem)) {
         case STRSXP:
-          data = (const unsigned char *) NANO_STRING(data_elem);
+          data = (const unsigned char *) CHAR(STRING_ELT(data_elem, 0));
           size = strlen((const char *) data);
           break;
         default:
@@ -1300,8 +1300,8 @@ SEXP rnng_stream_conn_set_header(SEXP xptr, SEXP name, SEXP value) {
   if (sc->headers_sent)
     Rf_error("cannot set header after headers have been sent");
 
-  const char *hdr_name = NANO_STRING(name);
-  const char *hdr_value = NANO_STRING(value);
+  const char *hdr_name = CHAR(STRING_ELT(name, 0));
+  const char *hdr_value = CHAR(STRING_ELT(value, 0));
 
   if (sc->resp_header_count >= sc->resp_header_capacity) {
     int new_cap = sc->resp_header_capacity == 0 ? 8 : sc->resp_header_capacity * 2;

--- a/src/server.c
+++ b/src/server.c
@@ -598,7 +598,7 @@ static void ws_invoke_onopen(void *arg) {
   }
 
   // on_open callback may have closed connection e.g. if not authorized
-  if (R_ExternalPtrAddr(ws->conn.xptr) == NULL)
+  if (NANO_PTR(ws->conn.xptr) == NULL)
     return;
 
   nano_http_server *srv = info->server;

--- a/src/thread.c
+++ b/src/thread.c
@@ -262,8 +262,9 @@ SEXP rnng_wait_thread_create(SEXP x) {
   } else if (typ == VECSXP) {
 
     const R_xlen_t xlen = Rf_xlength(x);
+    const SEXP *xp = VECTOR_PTR_RO(x);
     for (R_xlen_t i = 0; i < xlen; i++) {
-      rnng_wait_thread_create(NANO_VECTOR(x)[i]);
+      rnng_wait_thread_create(xp[i]);
     }
 
   }

--- a/src/tls.c
+++ b/src/tls.c
@@ -270,7 +270,7 @@ SEXP rnng_tls_config(SEXP client, SEXP server, SEXP pass, SEXP auth) {
       goto fail;
 
     if (usefile > 1) {
-      crl = NANO_STR_N(client, 1);
+      crl = CHAR(STRING_ELT(client, 1));
       if ((xc = nng_tls_config_ca_chain(cfg, file, strncmp(crl, "", 1) ? crl : NULL)))
         goto fail;
     } else {
@@ -288,7 +288,7 @@ SEXP rnng_tls_config(SEXP client, SEXP server, SEXP pass, SEXP auth) {
       goto fail;
 
     if (usefile > 1) {
-      key = NANO_STR_N(server, 1);
+      key = CHAR(STRING_ELT(server, 1));
       if ((xc = nng_tls_config_own_cert(cfg, file, key, pss)))
         goto fail;
     } else {

--- a/src/utils.c
+++ b/src/utils.c
@@ -171,7 +171,7 @@ SEXP rnng_set_opt(SEXP object, SEXP opt, SEXP value) {
       xc = nng_socket_set(*sock, op, NULL, 0);
       break;
     case STRSXP:
-      xc = nng_socket_set_string(*sock, op, NANO_STRING(value));
+      xc = nng_socket_set_string(*sock, op, CHAR(STRING_ELT(value, 0)));
       break;
     case REALSXP:
     case INTSXP:
@@ -205,7 +205,7 @@ SEXP rnng_set_opt(SEXP object, SEXP opt, SEXP value) {
       xc = nng_ctx_set(*ctx, op, NULL, 0);
       break;
     case STRSXP:
-      xc = nng_ctx_set_string(*ctx, op, NANO_STRING(value));
+      xc = nng_ctx_set_string(*ctx, op, CHAR(STRING_ELT(value, 0)));
       break;
     case REALSXP:
     case INTSXP:
@@ -233,7 +233,7 @@ SEXP rnng_set_opt(SEXP object, SEXP opt, SEXP value) {
       xc = nng_stream_set(*st, op, NULL, 0);
       break;
     case STRSXP:
-      xc = nng_stream_set_string(*st, op, NANO_STRING(value));
+      xc = nng_stream_set_string(*st, op, CHAR(STRING_ELT(value, 0)));
       break;
     case REALSXP:
     case INTSXP:
@@ -261,7 +261,7 @@ SEXP rnng_set_opt(SEXP object, SEXP opt, SEXP value) {
       xc = nng_listener_set(*list, op, NULL, 0);
       break;
     case STRSXP:
-      xc = nng_listener_set_string(*list, op, NANO_STRING(value));
+      xc = nng_listener_set_string(*list, op, CHAR(STRING_ELT(value, 0)));
       break;
     case REALSXP:
     case INTSXP:
@@ -289,7 +289,7 @@ SEXP rnng_set_opt(SEXP object, SEXP opt, SEXP value) {
       xc = nng_dialer_set(*dial, op, NULL, 0);
       break;
     case STRSXP:
-      xc = nng_dialer_set_string(*dial, op, NANO_STRING(value));
+      xc = nng_dialer_set_string(*dial, op, CHAR(STRING_ELT(value, 0)));
       break;
     case REALSXP:
     case INTSXP:


### PR DESCRIPTION
- [x] Replace internal vector and string macros
- [x] Preserve constness of `NANO_INTEGER()`