### PR TITLE
Update clamping code for iovs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # nanonext (development version)
 
+* Bundled NNG source updated (1.11.1-pre).
+
 # nanonext 1.9.0
 
 #### Performance

--- a/src/nng/src/core/aio.c
+++ b/src/nng/src/core/aio.c
@@ -609,11 +609,17 @@ nni_aio_iov_count(nni_aio *aio)
 	return (residual);
 }
 
-size_t
-nni_aio_iov_clamp_len(size_t len, size_t count)
+bool
+nni_aio_iov_clamp_len(size_t *len, size_t *count)
 {
-	size_t headroom = (size_t) INT_MAX - count;
-	return (len < headroom ? len : headroom);
+	NNI_ASSERT(*count <= (size_t) INT_MAX);
+	size_t headroom = (size_t) INT_MAX - *count;
+	bool   clamped  = *len > headroom;
+	if (clamped) {
+		*len = headroom;
+	}
+	*count += *len;
+	return clamped;
 }
 
 size_t

--- a/src/nng/src/core/aio.h
+++ b/src/nng/src/core/aio.h
@@ -74,7 +74,7 @@ extern void  nni_aio_set_prov_data(nni_aio *, void *);
 extern size_t nni_aio_iov_advance(nni_aio *, size_t);
 extern size_t nni_aio_iov_count(nni_aio *);
 
-extern size_t nni_aio_iov_clamp_len(size_t len, size_t count);
+extern bool nni_aio_iov_clamp_len(size_t *len, size_t *count);
 
 extern int nni_aio_set_iov(nni_aio *, unsigned, const nni_iov *);
 

--- a/src/nng/src/platform/posix/posix_ipcconn.c
+++ b/src/nng/src/platform/posix/posix_ipcconn.c
@@ -48,6 +48,7 @@ ipc_dowrite(ipc_conn *c)
 		struct msghdr hdr;
 		struct iovec  iovec[16];
 		size_t        count;
+		bool          clamped;
 
 		memset(&hdr, 0, sizeof(hdr));
 		nni_aio_get_iov(aio, &naiov, &aiov);
@@ -58,14 +59,14 @@ ipc_dowrite(ipc_conn *c)
 			continue;
 		}
 
-		count = 0;
-		for (niov = 0, i = 0; i < naiov; i++) {
+		count   = 0;
+		clamped = false;
+		for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
-				size_t len = nni_aio_iov_clamp_len(
-				    aiov[i].iov_len, count);
-				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
-				count += len;
+				iovec[niov].iov_len  = aiov[i].iov_len;
+				clamped = nni_aio_iov_clamp_len(
+				    &iovec[niov].iov_len, &count);
 				niov++;
 			}
 		}
@@ -117,6 +118,7 @@ ipc_doread(ipc_conn *c)
 		nni_iov     *aiov;
 		struct iovec iovec[16];
 		size_t       count;
+		bool         clamped;
 
 		nni_aio_get_iov(aio, &naiov, &aiov);
 		if (naiov > NNI_NUM_ELEMENTS(iovec)) {
@@ -124,14 +126,14 @@ ipc_doread(ipc_conn *c)
 			nni_aio_finish_error(aio, NNG_EINVAL);
 			continue;
 		}
-		count = 0;
-		for (niov = 0, i = 0; i < naiov; i++) {
+		count   = 0;
+		clamped = false;
+		for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				size_t len = nni_aio_iov_clamp_len(
-				    aiov[i].iov_len, count);
-				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
-				count += len;
+				iovec[niov].iov_len  = aiov[i].iov_len;
+				clamped = nni_aio_iov_clamp_len(
+				    &iovec[niov].iov_len, &count);
 				niov++;
 			}
 		}

--- a/src/nng/src/platform/posix/posix_tcpconn.c
+++ b/src/nng/src/platform/posix/posix_tcpconn.c
@@ -47,6 +47,7 @@ tcp_dowrite(nni_tcp_conn *c)
 		struct msghdr hdr;
 		struct iovec  iovec[16];
 		size_t        count;
+		bool          clamped;
 
 		memset(&hdr, 0, sizeof(hdr));
 		nni_aio_get_iov(aio, &naiov, &aiov);
@@ -57,14 +58,14 @@ tcp_dowrite(nni_tcp_conn *c)
 			continue;
 		}
 
-		count = 0;
-		for (niov = 0, i = 0; i < naiov; i++) {
+		count   = 0;
+		clamped = false;
+		for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
-				size_t len = nni_aio_iov_clamp_len(
-				    aiov[i].iov_len, count);
-				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
-				count += len;
+				iovec[niov].iov_len  = aiov[i].iov_len;
+				clamped = nni_aio_iov_clamp_len(
+				    &iovec[niov].iov_len, &count);
 				niov++;
 			}
 		}
@@ -116,6 +117,7 @@ tcp_doread(nni_tcp_conn *c)
 		nni_iov *    aiov;
 		struct iovec iovec[16];
 		size_t       count;
+		bool         clamped;
 
 		nni_aio_get_iov(aio, &naiov, &aiov);
 		if (naiov > NNI_NUM_ELEMENTS(iovec)) {
@@ -123,14 +125,14 @@ tcp_doread(nni_tcp_conn *c)
 			nni_aio_finish_error(aio, NNG_EINVAL);
 			continue;
 		}
-		count = 0;
-		for (niov = 0, i = 0; i < naiov; i++) {
+		count   = 0;
+		clamped = false;
+		for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				size_t len = nni_aio_iov_clamp_len(
-				    aiov[i].iov_len, count);
-				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
-				count += len;
+				iovec[niov].iov_len  = aiov[i].iov_len;
+				clamped = nni_aio_iov_clamp_len(
+				    &iovec[niov].iov_len, &count);
 				niov++;
 			}
 		}

--- a/src/nng/src/platform/windows/win_tcpconn.c
+++ b/src/nng/src/platform/windows/win_tcpconn.c
@@ -29,6 +29,7 @@ tcp_recv_start(nni_tcp_conn *c)
 	WSABUF   iov[8];
 	DWORD    nrecv;
 	size_t   count;
+	bool     clamped;
 
 	c->recv_rv = 0;
 	while ((aio = nni_list_first(&c->recv_aios)) != NULL) {
@@ -40,13 +41,14 @@ tcp_recv_start(nni_tcp_conn *c)
 	  }
 	  nni_aio_get_iov(aio, &naiov, &aiov);
 
-	  count = 0;
-	  for (niov = 0, i = 0; i < naiov; i++) {
+	  count   = 0;
+	  clamped = false;
+	  for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 	    if (aiov[i].iov_len != 0) {
-	      size_t len = nni_aio_iov_clamp_len(aiov[i].iov_len, count);
+	      size_t len = aiov[i].iov_len;
+	      clamped = nni_aio_iov_clamp_len(&len, &count);
 	      iov[niov].buf = aiov[i].iov_buf;
 	      iov[niov].len = (ULONG) len;
-	      count += len;
 	      niov++;
 	    }
 	  }
@@ -149,6 +151,7 @@ tcp_send_start(nni_tcp_conn *c)
 	unsigned naiov;
 	nni_iov *aiov;
 	WSABUF   iov[8];
+	bool     clamped;
 
 	while ((aio = nni_list_first(&c->send_aios)) != NULL) {
 	  if (c->closed) {
@@ -158,13 +161,14 @@ tcp_send_start(nni_tcp_conn *c)
 	  }
 	  nni_aio_get_iov(aio, &naiov, &aiov);
 
-	  count = 0;
-	  for (niov = 0, i = 0; i < naiov; i++) {
+	  count   = 0;
+	  clamped = false;
+	  for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 	    if (aiov[i].iov_len != 0) {
-	      size_t len = nni_aio_iov_clamp_len(aiov[i].iov_len, count);
+	      size_t len = aiov[i].iov_len;
+	      clamped = nni_aio_iov_clamp_len(&len, &count);
 	      iov[niov].buf = aiov[i].iov_buf;
 	      iov[niov].len = (ULONG) len;
-	      count += len;
 	      niov++;
 	    }
 	  }


### PR DESCRIPTION
Fixes #290. Follow up to #267 and #267.
These mirror the changes accepted upstream.