### PR TITLE
Inject Emscripten link-time tuning for pthread-WASM builds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 # nanonext (development version)
 
-* Bundled NNG source updated (1.11.1-pre).
+#### Updates
+
+* Adds support for building against pthread-enabled WebAssembly targets (e.g. a pthread variant of webR).
+* Updates bundled NNG source (1.11.1-pre).
 
 # nanonext 1.9.0
 

--- a/configure
+++ b/configure
@@ -71,6 +71,16 @@ int main() {
     ;;
 esac
 
+# Inject Emscripten link-time tuning when building pthread-WASM
+case "$CC" in
+  *emcc*)
+    if echo " $CFLAGS $PKG_CFLAGS " | grep -q ' -pthread '; then
+      echo "Detected pthread-WASM target"
+      PKG_LIBS="$PKG_LIBS -s PTHREAD_POOL_SIZE=16 -s ALLOW_MEMORY_GROWTH=1 -s INITIAL_MEMORY=33554432"
+    fi
+    ;;
+esac
+
 # Determine whether to compile bundled libraries
 compile_mbedtls=0
 compile_nng=0


### PR DESCRIPTION
Follow up to #293.

@georgestagg as we discussed, with a webR that's compiled with `-pthread` and includes `-pthread` in `WASM_CFLAGS` and `WASM_LDFLAGS`, all IPC transports should just work (tcp/ws require additional workarounds).

## Summary
- When `configure` detects an emcc target with `-pthread` in inherited `CFLAGS`/`PKG_CFLAGS`, append `-s PTHREAD_POOL_SIZE=16 -s ALLOW_MEMORY_GROWTH=1 -s INITIAL_MEMORY=33554432` to `PKG_LIBS`.
- Native builds and non-pthread WASM builds are byte-identical to before (block only fires when both `*emcc*` and a whole-token `-pthread` match).
- Phase 1 of the pthread-WASM plan: inert opt-in infrastructure that activates once rwasm propagates `-pthread`.

## Test plan
- [x] Native `./configure` on macOS arm64 produces unchanged `src/Makevars`
- [x] Stubbed emcc + no `-pthread` → no `-s` flags injected
- [x] Stubbed emcc + `-pthread` in `CFLAGS` → `-s` flags appear in `PKG_LIBS`
- [x] Stubbed emcc + `-pthread-foo` substring → no injection (whitespace guard holds)