### PR TITLE
Reserve message headroom when installing a serialized buffer body

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 #### Updates
 
+* Fixes potential message corruption when built against a system 'libnng', regression in 1.9.0 (#301).
 * Removes the build-time dependency on 'cmake'. Compiling the bundled NNG and Mbed TLS sources now only require a C compiler.
 * Trims the bundled mbedTLS source to remove unused modules.
 * Falls back to a non-functional stub build on platforms that cannot compile the bundled NNG, keeping nanonext and its dependents installable everywhere.

--- a/src/aio.c
+++ b/src/aio.c
@@ -731,7 +731,7 @@ SEXP rnng_send_aio(SEXP con, SEXP data, SEXP mode, SEXP timeout, SEXP pipe, SEXP
     if (raw) {
       nano_encode(&buf, data);
     } else {
-      nano_serialize(&buf, data, NANO_PROT(con), 0);
+      nano_serialize(&buf, data, NANO_PROT(con), 0, NANO_HEADROOM);
     }
     nng_msg *msg = NULL;
 
@@ -745,7 +745,7 @@ SEXP rnng_send_aio(SEXP con, SEXP data, SEXP mode, SEXP timeout, SEXP pipe, SEXP
       goto fail;
     }
 
-    nano_msg_set_body(msg, &buf);
+    nano_msg_set_body(msg, &buf, raw ? 0 : NANO_HEADROOM);
 
     if (pipeid) {
       nng_pipe p;

--- a/src/comms.c
+++ b/src/comms.c
@@ -365,14 +365,14 @@ SEXP rnng_send(SEXP con, SEXP data, SEXP mode, SEXP block, SEXP pipe) {
     if (raw) {
       nano_encode(&buf, data);
     } else {
-      nano_serialize(&buf, data, NANO_PROT(con), 0);
+      nano_serialize(&buf, data, NANO_PROT(con), 0, NANO_HEADROOM);
     }
     nng_msg *msgp = NULL;
 
     if ((xc = nng_msg_alloc(&msgp, 0)))
       goto fail;
 
-    nano_msg_set_body(msgp, &buf);
+    nano_msg_set_body(msgp, &buf, raw ? 0 : NANO_HEADROOM);
 
     if (pipeid) {
       nng_pipe p;

--- a/src/core.c
+++ b/src/core.c
@@ -302,17 +302,21 @@ SEXP nano_url_with_port(nng_url *up, int port) {
 
 }
 
-void nano_serialize(nano_buf *buf, SEXP object, SEXP hook, int header) {
+void nano_serialize(nano_buf *buf, SEXP object, SEXP hook, int header, size_t headroom) {
 
   NANO_ALLOC(buf, NANONEXT_INIT_BUFSIZE);
   struct R_outpstream_st output_stream;
 
+  // Reserve headroom so a zero-copy body (nano_msg_set_body) leaves room for
+  // NNG to prepend protocol headers in place, as a native nng_msg would.
+  buf->cur = headroom;
+
   if (header || special_marker) {
-    memset(buf->buf, 0, 8);
-    buf->buf[0] = 0x7;
-    buf->buf[3] = (uint8_t) special_marker;
+    memset(buf->buf + headroom, 0, 8);
+    buf->buf[headroom] = 0x7;
+    buf->buf[headroom + 3] = (uint8_t) special_marker;
     if (header)
-      memcpy(buf->buf + 4, &header, sizeof(int));
+      memcpy(buf->buf + headroom + 4, &header, sizeof(int));
     buf->cur += 8;
   }
 
@@ -336,15 +340,15 @@ void nano_serialize(nano_buf *buf, SEXP object, SEXP hook, int header) {
 
 }
 
-void nano_msg_set_body(nng_msg *msg, nano_buf *buf) {
+void nano_msg_set_body(nng_msg *msg, nano_buf *buf, size_t headroom) {
 
   if (buf->len) {
     nano_nng_msg *m = (nano_nng_msg *) msg;
     free(m->body.buf);
     m->body.buf = buf->buf;
-    m->body.ptr = buf->buf;
-    m->body.len = buf->cur;
-    m->body.cap = buf->len;
+    m->body.ptr = buf->buf + headroom;
+    m->body.len = buf->cur - headroom;
+    m->body.cap = buf->cur;
     buf->len = 0;
   } else {
     nng_msg_append(msg, buf->buf, buf->cur);

--- a/src/dispatcher.c
+++ b/src/dispatcher.c
@@ -303,7 +303,7 @@ static int dispatch_prepare_init_template(nano_dispatcher *d, SEXP stream,
   SET_VECTOR_ELT(init_data, 1, serial);
 
   nano_buf buf;
-  nano_serialize(&buf, init_data, serial, 0);
+  nano_serialize(&buf, init_data, serial, 0, 0);
   UNPROTECT(1);
 
   memcpy(sdata + 1, saved, 6 * sizeof(int));
@@ -834,7 +834,7 @@ SEXP rnng_dispatcher_start(SEXP url, SEXP disp_url, SEXP tls,
   SEXP err;
   PROTECT(err = mk_error(19));
   nano_buf reset_buf;
-  nano_serialize(&reset_buf, err, R_NilValue, 0);
+  nano_serialize(&reset_buf, err, R_NilValue, 0, 0);
   UNPROTECT(1);
   d->conn_reset_buf = reset_buf.buf;
   d->conn_reset_len = reset_buf.cur;

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -125,6 +125,7 @@ extern int R_interrupts_pending;
 #define ERROR_OUT(xc) Rf_error("%d | %s", xc, nng_strerror(xc))
 #define ERROR_RET(xc) { Rf_warning("%d | %s", xc, nng_strerror(xc)); return mk_error(xc); }
 #define NANONEXT_INIT_BUFSIZE 4096
+#define NANO_HEADROOM 32
 #define NANONEXT_SERIAL_VER 3
 #define NANONEXT_SERIAL_THR 67108864
 #define NANONEXT_CHUNK_SIZE 67108864 // must be <= INT_MAX
@@ -434,8 +435,8 @@ void haio_invoke_cb(void *);
 SEXP mk_error(const int);
 SEXP mk_error_data(const int);
 SEXP nano_raw_char(const unsigned char *, const size_t);
-void nano_serialize(nano_buf *, const SEXP, SEXP, int);
-void nano_msg_set_body(nng_msg *, nano_buf *);
+void nano_serialize(nano_buf *, const SEXP, SEXP, int, size_t);
+void nano_msg_set_body(nng_msg *, nano_buf *, size_t);
 SEXP nano_unserialize(unsigned char *, const size_t, SEXP);
 SEXP nano_decode(unsigned char *, const size_t, const uint8_t, SEXP);
 SEXP nano_url_with_port(nng_url *, int);

--- a/src/sync.c
+++ b/src/sync.c
@@ -485,7 +485,7 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
   if (raw) {
     nano_encode(&buf, data);
   } else {
-    nano_serialize(&buf, data, NANO_PROT(con), id);
+    nano_serialize(&buf, data, NANO_PROT(con), id, NANO_HEADROOM);
   }
 
   saio = calloc(1, sizeof(nano_saio));
@@ -510,7 +510,7 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
     goto fail;
   }
 
-  nano_msg_set_body(msg, &buf);
+  nano_msg_set_body(msg, &buf, raw ? 0 : NANO_HEADROOM);
 
   nng_aio_set_msg(saio->aio, msg);
   nng_ctx_send(*ctx, saio->aio);


### PR DESCRIPTION
## Summary

Fixes message-body corruption that surfaces when nanonext is linked against a separately-built `libnng` (e.g. the released 1.11.0 on R-universe's Linux images): serialized messages round-trip as unserializable garbage and `R CMD check` fails in the test phase.

## How it works

`nano_msg_set_body` installs the serialization buffer as a message body zero-copy by writing the body chunk fields directly, with `ch_ptr == ch_buf` — i.e. **zero headroom**. A native `nng_msg` always carries ~32 bytes of leading headroom (the `sz + 32, 32` in `nni_msg_alloc`) so protocols can prepend their header in place.

With zero headroom, the header prepend on the inproc req/rep path (`nni_msg_pull_up` → `nni_chunk_insert`) is forced down a branch whose implementation differs between NNG versions. The bundled NNG handles it correctly; a released 1.11.0 `nni_chunk_insert` (a rewritten "split/centre" variant) writes the header over the start of the body, mangling it — length preserved, content garbage, so the receiver reports "received data could not be unserialized". This is a source difference in `message.c`, not a build/config difference, and it is latent for the bundled build too (a future NNG re-vendor would hit it).

This reserves `NANO_HEADROOM` (32, matching NNG's native allocation) at the front during serialization and points the donated body past it: `ch_ptr = ch_buf + headroom`, `ch_len = cur - headroom`, `ch_cap = cur`. The donated message is then structurally identical to a native `nng_msg` (headroom 32, room 32), so the prepend stays on the in-place `len <= headroom` branch on every NNG version. The raw/encode and dispatcher buffers pass headroom 0 (behaviour unchanged).