### PR TITLE
Fix implicit integer conversion warnings under -Wconversion

### DIFF
--- a/src/aio.c
+++ b/src/aio.c
@@ -843,7 +843,7 @@ SEXP rnng_recv_aio(SEXP con, SEXP mode, SEXP timeout, SEXP cvar, SEXP clo) {
 
   if ((sock = !NANO_PTR_CHECK(con, nano_SocketSymbol)) || !NANO_PTR_CHECK(con, nano_ContextSymbol)) {
 
-    const uint8_t mod = (uint8_t) nano_matcharg(mode);
+    const uint8_t mod = nano_matcharg(mode);
     raio = calloc(1, sizeof(nano_aio));
     NANO_ENSURE_ALLOC(raio);
     raio->next = ncv;
@@ -862,7 +862,9 @@ SEXP rnng_recv_aio(SEXP con, SEXP mode, SEXP timeout, SEXP cvar, SEXP clo) {
 
   } else if (!NANO_PTR_CHECK(con, nano_StreamSymbol)) {
 
-    const uint8_t mod = (uint8_t) (nano_matcharg(mode) == 1 ? 2 : nano_matcharg(mode));
+    uint8_t mod = nano_matcharg(mode);
+    if (mod == 1)
+      mod = 2;
     nano_stream *nst = (nano_stream *) NANO_PTR(con);
     nng_stream *sp = nst->stream;
 

--- a/src/comms.c
+++ b/src/comms.c
@@ -479,7 +479,7 @@ SEXP rnng_recv(SEXP con, SEXP mode, SEXP block) {
 
   if (!NANO_PTR_CHECK(con, nano_SocketSymbol)) {
 
-    const int mod = nano_matcharg(mode);
+    const uint8_t mod = nano_matcharg(mode);
     nng_socket *sock = (nng_socket *) NANO_PTR(con);
     nng_msg *msgp = NULL;
 
@@ -510,7 +510,7 @@ SEXP rnng_recv(SEXP con, SEXP mode, SEXP block) {
 
   } else if (!NANO_PTR_CHECK(con, nano_ContextSymbol)) {
 
-    const int mod = nano_matcharg(mode);
+    const uint8_t mod = nano_matcharg(mode);
     nng_ctx *ctxp = (nng_ctx *) NANO_PTR(con);
     nng_msg *msgp = NULL;
 
@@ -550,7 +550,9 @@ SEXP rnng_recv(SEXP con, SEXP mode, SEXP block) {
 
   } else if (!NANO_PTR_CHECK(con, nano_StreamSymbol)) {
 
-    const int mod = nano_matcharg(mode) == 1 ? 2 : nano_matcharg(mode);
+    uint8_t mod = nano_matcharg(mode);
+    if (mod == 1)
+      mod = 2;
     nano_stream *nst = (nano_stream *) NANO_PTR(con);
     nng_stream *sp = nst->stream;
     nng_aio *aiop = NULL;

--- a/src/core.c
+++ b/src/core.c
@@ -560,14 +560,14 @@ int nano_encode_mode(const SEXP mode) {
 
 }
 
-int nano_matcharg(const SEXP mode) {
+uint8_t nano_matcharg(const SEXP mode) {
 
   if (TYPEOF(mode) == INTSXP)
-    return NANO_INTEGER(mode);
+    return (uint8_t) NANO_INTEGER(mode);
 
   const char *mod = CHAR(STRING_ELT(mode, 0));
   size_t slen = strlen(mod);
-  int i;
+  uint8_t i;
   switch (slen) {
   case 3:
     if (!memcmp(mod, "raw", slen)) { i = 8; break; }

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -442,7 +442,7 @@ SEXP nano_decode(unsigned char *, const size_t, const uint8_t, SEXP);
 SEXP nano_url_with_port(nng_url *, int);
 void nano_encode(nano_buf *, const SEXP);
 int nano_encode_mode(const SEXP);
-int nano_matcharg(const SEXP);
+uint8_t nano_matcharg(const SEXP);
 SEXP nano_aio_result(SEXP);
 SEXP nano_aio_get_msg(SEXP);
 SEXP nano_aio_http_status(SEXP);

--- a/src/nng/src/platform/posix/posix_clock.c
+++ b/src/nng/src/platform/posix/posix_clock.c
@@ -26,21 +26,21 @@ nni_time_get(uint64_t *sec, uint32_t *nsec)
 	struct timespec ts;
 	if ((rv = timespec_get(&ts, TIME_UTC)) == TIME_UTC) {
 		*sec  = ts.tv_sec;
-		*nsec = ts.tv_nsec;
+		*nsec = (uint32_t) ts.tv_nsec;
 		return (0);
 	}
 #elif defined(NNG_HAVE_CLOCK_GETTIME)
 	struct timespec ts;
 	if ((rv = clock_gettime(CLOCK_REALTIME, &ts)) == 0) {
 		*sec  = ts.tv_sec;
-		*nsec = ts.tv_nsec;
+		*nsec = (uint32_t) ts.tv_nsec;
 		return (0);
 	}
 #else
 	struct timeval tv;
 	if ((rv = gettimeofday(&tv, NULL)) == 0) {
 		*sec  = tv.tv_sec;
-		*nsec = tv.tv_usec * 1000;
+		*nsec = (uint32_t) (tv.tv_usec * 1000);
 		return (0);
 	}
 #endif

--- a/src/nng/src/platform/posix/posix_udp.c
+++ b/src/nng/src/platform/posix/posix_udp.c
@@ -397,7 +397,7 @@ nni_plat_udp_multicast_membership(
 	socklen_t               sz;
 	int                     rv;
 
-	sz = nni_posix_nn2sockaddr(&ss, sa);
+	sz = (socklen_t) nni_posix_nn2sockaddr(&ss, sa);
 	if (sz < 1) {
 		return (NNG_EADDRINVAL);
 	}

--- a/src/server.c
+++ b/src/server.c
@@ -624,7 +624,7 @@ static void ws_invoke_onmessage(void *arg) {
 
   SEXP data;
   if (info->textframes) {
-    PROTECT(data = Rf_ScalarString(Rf_mkCharLenCE((char *) buf, len, CE_UTF8)));
+    PROTECT(data = Rf_ScalarString(Rf_mkCharLenCE((char *) buf, (int) len, CE_UTF8)));
   } else {
     PROTECT(data = Rf_allocVector(RAWSXP, len));
     memcpy(NANO_DATAPTR(data), buf, len);
@@ -683,7 +683,7 @@ SEXP rnng_http_server_create(SEXP url, SEXP handlers, SEXP tls) {
   }
   srv->xptr = R_NilValue;
   srv->prot = R_NilValue;
-  srv->handler_count = handler_count;
+  srv->handler_count = (int) handler_count;
   for (R_xlen_t i = 0; i < handler_count; i++) {
     srv->handlers[i].callback = R_NilValue;
     srv->handlers[i].on_open = R_NilValue;

--- a/src/sync.c
+++ b/src/sync.c
@@ -468,7 +468,7 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
   nng_ctx *ctx = (nng_ctx *) NANO_PTR(con);
 
   const nng_duration dur = timeout == R_NilValue ? NNG_DURATION_DEFAULT : (nng_duration) nano_integer(timeout);
-  const uint8_t mod = (uint8_t) nano_matcharg(recvmode);
+  const uint8_t mod = nano_matcharg(recvmode);
   const int raw = nano_encode_mode(sendmode);
   const int id = nng_ctx_id(*ctx);
   const int signal = cvar != R_NilValue && !NANO_PTR_CHECK(cvar, nano_CvSymbol);

--- a/tools/patch_nng.sh
+++ b/tools/patch_nng.sh
@@ -70,6 +70,7 @@ patch_perl platform/posix/posix_udp.c '
   s/\bcnt = sendmsg\(udp->udp_fd/cnt = (int) sendmsg(udp->udp_fd/;
   s/\blen = nni_posix_nn2sockaddr\(&ss, nni_aio_get_input/len = (int) nni_posix_nn2sockaddr(&ss, nni_aio_get_input/;
   s/\(salen = nni_posix_nn2sockaddr\(/(salen = (int) nni_posix_nn2sockaddr(/;
+  s/\bsz = nni_posix_nn2sockaddr\(&ss, sa\);/sz = (socklen_t) nni_posix_nn2sockaddr(&ss, sa);/;
 '
 patch_perl platform/posix/posix_tcpconn.c '
   s/\bn = sendmsg\(fd\b/n = (int) sendmsg(fd/;
@@ -106,6 +107,12 @@ patch_perl platform/posix/posix_sockaddr.c '
 '
 patch_perl platform/posix/posix_thread.c '
   s/return \(sysconf\(_SC_NPROCESSORS_ONLN\)\);/return ((int) sysconf(_SC_NPROCESSORS_ONLN));/;
+'
+# clock: tv_nsec (long) and the usec*1000 product narrowed to the uint32_t
+# *nsec out-param (both the timespec and gettimeofday code paths).
+patch_perl platform/posix/posix_clock.c '
+  s/\*nsec = ts\.tv_nsec;/*nsec = (uint32_t) ts.tv_nsec;/g;
+  s/\*nsec = tv\.tv_usec \* 1000;/*nsec = (uint32_t) (tv.tv_usec * 1000);/;
 '
 # signed char passed to toupper(); narrow the int result back to char.
 patch_perl core/url.c '


### PR DESCRIPTION
Clears the implicit integer-conversion warnings produced under `-Wconversion -Wno-sign-conversion` in nanonext's own sources and the vendored NNG.