### PR TITLE
Apply narrowing casts to vendored Mbed TLS sources

### DIFF
--- a/src/mbedtls/library/aes.c
+++ b/src/mbedtls/library/aes.c
@@ -311,7 +311,7 @@ MBEDTLS_MAYBE_UNUSED static uint32_t RT3[256];
 MBEDTLS_MAYBE_UNUSED static uint32_t round_constants[10];
 
 #define ROTL8(x) (((x) << 8) & 0xFFFFFFFF) | ((x) >> 24)
-#define XTIME(x) (((x) << 1) ^ (((x) & 0x80) ? 0x1B : 0x00))
+#define XTIME(x) ((uint8_t) (((x) << 1) ^ (((x) & 0x80) ? 0x1B : 0x00)))
 #define MUL(x, y) (((x) && (y)) ? pow[(log[(x)]+log[(y)]) % 255] : 0)
 
 MBEDTLS_MAYBE_UNUSED static int aes_init_done = 0;
@@ -342,10 +342,10 @@ MBEDTLS_MAYBE_UNUSED static void aes_gen_tables(void)
     for (i = 1; i < 256; i++) {
         x = pow[255 - log[i]];
 
-        y  = x; y = (y << 1) | (y >> 7);
-        x ^= y; y = (y << 1) | (y >> 7);
-        x ^= y; y = (y << 1) | (y >> 7);
-        x ^= y; y = (y << 1) | (y >> 7);
+        y  = x; y = (uint8_t) ((y << 1) | (y >> 7));
+        x ^= y; y = (uint8_t) ((y << 1) | (y >> 7));
+        x ^= y; y = (uint8_t) ((y << 1) | (y >> 7));
+        x ^= y; y = (uint8_t) ((y << 1) | (y >> 7));
         x ^= y ^ 0x63;
 
         FSb[i] = x;

--- a/src/mbedtls/library/asn1parse.c
+++ b/src/mbedtls/library/asn1parse.c
@@ -319,7 +319,7 @@ int mbedtls_asn1_get_sequence_of(unsigned char **p,
     asn1_get_sequence_of_cb_ctx_t cb_ctx = { tag, cur };
     memset(cur, 0, sizeof(mbedtls_asn1_sequence));
     return mbedtls_asn1_traverse_sequence_of(
-        p, end, 0xFF, tag, 0, 0,
+        p, end, 0xFF, (unsigned char) tag, 0, 0,
         asn1_get_sequence_of_cb, &cb_ctx);
 }
 

--- a/src/mbedtls/library/asn1write.c
+++ b/src/mbedtls/library/asn1write.c
@@ -212,7 +212,7 @@ static int asn1_write_tagged_int(unsigned char **p, const unsigned char *start, 
         len += 1;
     }
 
-    return mbedtls_asn1_write_len_and_tag(p, start, len, tag);
+    return mbedtls_asn1_write_len_and_tag(p, start, len, (unsigned char) tag);
 }
 
 int mbedtls_asn1_write_int(unsigned char **p, const unsigned char *start, int val)
@@ -235,7 +235,7 @@ int mbedtls_asn1_write_tagged_string(unsigned char **p, const unsigned char *sta
                                                             (const unsigned char *) text,
                                                             text_len));
 
-    return mbedtls_asn1_write_len_and_tag(p, start, len, tag);
+    return mbedtls_asn1_write_len_and_tag(p, start, len, (unsigned char) tag);
 }
 
 int mbedtls_asn1_write_utf8_string(unsigned char **p, const unsigned char *start,

--- a/src/mbedtls/library/bignum.c
+++ b/src/mbedtls/library/bignum.c
@@ -104,7 +104,7 @@ int mbedtls_mpi_safe_cond_swap(mbedtls_mpi *X,
 
     s = X->s;
     X->s = mbedtls_ct_mpi_sign_if(do_swap, Y->s, X->s);
-    Y->s = mbedtls_ct_mpi_sign_if(do_swap, s, Y->s);
+    Y->s = mbedtls_ct_mpi_sign_if(do_swap, (short) s, Y->s);
 
     mbedtls_mpi_core_cond_swap(X->p, Y->p, X->n, do_swap);
 
@@ -272,7 +272,7 @@ static inline mbedtls_mpi_uint mpi_sint_abs(mbedtls_mpi_sint z)
     return (mbedtls_mpi_uint) 0 - (mbedtls_mpi_uint) z;
 }
 
-#define TO_SIGN(x) ((mbedtls_mpi_sint) (((mbedtls_mpi_uint) x) >> (biL - 1)) * -2 + 1)
+#define TO_SIGN(x) ((short) ((mbedtls_mpi_sint) (((mbedtls_mpi_uint) x) >> (biL - 1)) * -2 + 1))
 
 int mbedtls_mpi_lset(mbedtls_mpi *X, mbedtls_mpi_sint z)
 {
@@ -909,15 +909,15 @@ static int add_sub_mpi(mbedtls_mpi *X,
         if (cmp >= 0) {
             MBEDTLS_MPI_CHK(mbedtls_mpi_sub_abs(X, A, B));
 
-            X->s = cmp == 0 ? 1 : s;
+            X->s = (short) (cmp == 0 ? 1 : s);
         } else {
             MBEDTLS_MPI_CHK(mbedtls_mpi_sub_abs(X, B, A));
 
-            X->s = -s;
+            X->s = (short) -s;
         }
     } else {
         MBEDTLS_MPI_CHK(mbedtls_mpi_add_abs(X, A, B));
-        X->s = s;
+        X->s = (short) s;
     }
 
 cleanup:

--- a/src/mbedtls/library/ccm.c
+++ b/src/mbedtls/library/ccm.c
@@ -196,7 +196,7 @@ int mbedtls_ccm_starts(mbedtls_ccm_context *ctx,
     ctx->q = 16 - 1 - (unsigned char) iv_len;
 
     memset(ctx->ctr, 0, 16);
-    ctx->ctr[0] = ctx->q - 1;
+    ctx->ctr[0] = (unsigned char) (ctx->q - 1);
     memcpy(ctx->ctr + 1, iv, iv_len);
     memset(ctx->ctr + 1 + iv_len, 0, ctx->q);
     ctx->ctr[15] = 1;

--- a/src/mbedtls/library/constant_time.c
+++ b/src/mbedtls/library/constant_time.c
@@ -114,9 +114,9 @@ void mbedtls_ct_memmove_left(void *start, size_t total, size_t offset)
         for (size_t n = 0; n < total - 1; n++) {
             unsigned char current = buf[n];
             unsigned char next    = buf[n+1];
-            buf[n] = mbedtls_ct_uint_if(no_op, current, next);
+            buf[n] = (unsigned char) mbedtls_ct_uint_if(no_op, current, next);
         }
-        buf[total-1] = mbedtls_ct_uint_if_else_0(no_op, buf[total-1]);
+        buf[total-1] = (unsigned char) mbedtls_ct_uint_if_else_0(no_op, buf[total-1]);
     }
 }
 

--- a/src/mbedtls/library/ctr_drbg.c
+++ b/src/mbedtls/library/ctr_drbg.c
@@ -177,7 +177,7 @@ static int block_cipher_df(unsigned char *output,
     buf_len = MBEDTLS_CTR_DRBG_BLOCKSIZE + 8 + data_len + 1;
 
     for (i = 0; i < MBEDTLS_CTR_DRBG_KEYSIZE; i++) {
-        key[i] = i;
+        key[i] = (unsigned char) i;
     }
 
 #if defined(MBEDTLS_CTR_DRBG_USE_PSA_CRYPTO)

--- a/src/mbedtls/library/ecp.c
+++ b/src/mbedtls/library/ecp.c
@@ -570,7 +570,7 @@ int mbedtls_ecp_point_write_binary(const mbedtls_ecp_group *grp,
                 return MBEDTLS_ERR_ECP_BUFFER_TOO_SMALL;
             }
 
-            buf[0] = 0x02 + mbedtls_mpi_get_bit(&P->Y, 0);
+            buf[0] = (unsigned char) (0x02 + mbedtls_mpi_get_bit(&P->Y, 0));
             MBEDTLS_MPI_CHK(mbedtls_mpi_write_binary(&P->X, buf + 1, plen));
         }
     }
@@ -1357,7 +1357,7 @@ static int ecp_precompute_comb(const mbedtls_ecp_group *grp,
     int ret = MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
     unsigned char i;
     size_t j = 0;
-    const unsigned char T_size = 1U << (w - 1);
+    const unsigned char T_size = (unsigned char) (1U << (w - 1));
     mbedtls_ecp_point *cur, *TT[COMB_MAX_PRE - 1] = { NULL };
 
     mbedtls_mpi tmp[4];
@@ -1405,7 +1405,7 @@ dbl:
     for (; j < d * (w - 1); j++) {
         MBEDTLS_ECP_BUDGET(MBEDTLS_ECP_OPS_DBL);
 
-        i = 1U << (j / d);
+        i = (unsigned char) (1U << (j / d));
         cur = T + i;
 
         if (j % d == 0) {
@@ -1701,7 +1701,7 @@ static int ecp_mul_comb(mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
 #endif
 
     w = ecp_pick_window_size(grp, p_eq_g);
-    T_size = 1U << (w - 1);
+    T_size = (unsigned char) (1U << (w - 1));
     d = (grp->nbits + w - 1) / w;
 
     if (p_eq_g && grp->T != NULL) {
@@ -1917,7 +1917,7 @@ static int ecp_mul_mxz(mbedtls_ecp_group *grp, mbedtls_ecp_point *R,
 
     i = grp->nbits + 1;
     while (i-- > 0) {
-        b = mbedtls_mpi_get_bit(m, i);
+        b = (unsigned char) mbedtls_mpi_get_bit(m, i);
 
         MPI_ECP_COND_SWAP(&R->X, &RP.X, b);
         MPI_ECP_COND_SWAP(&R->Z, &RP.Z, b);

--- a/src/mbedtls/library/gcm.c
+++ b/src/mbedtls/library/gcm.c
@@ -363,7 +363,7 @@ int mbedtls_gcm_starts(mbedtls_gcm_context *ctx,
     memset(ctx->y, 0x00, sizeof(ctx->y));
     memset(ctx->buf, 0x00, sizeof(ctx->buf));
 
-    ctx->mode = mode;
+    ctx->mode = (unsigned char) mode;
     ctx->len = 0;
     ctx->add_len = 0;
 

--- a/src/mbedtls/library/ssl_msg.c
+++ b/src/mbedtls/library/ssl_msg.c
@@ -1878,7 +1878,7 @@ static int ssl_flight_append(mbedtls_ssl_context *ssl)
 
     memcpy(msg->p, ssl->out_msg, ssl->out_msglen);
     msg->len = ssl->out_msglen;
-    msg->type = ssl->out_msgtype;
+    msg->type = (unsigned char) ssl->out_msgtype;
     msg->next = NULL;
 
     if (ssl->handshake->flight == NULL) {
@@ -2302,7 +2302,7 @@ int mbedtls_ssl_write_record(mbedtls_ssl_context *ssl, int force_flush)
 
             memcpy(&rec.ctr[0], ssl->out_ctr, sizeof(rec.ctr));
             mbedtls_ssl_write_version(rec.ver, ssl->conf->transport, tls_ver);
-            rec.type = ssl->out_msgtype;
+            rec.type = (uint8_t) ssl->out_msgtype;
 
 #if defined(MBEDTLS_SSL_DTLS_CONNECTION_ID)
 
@@ -5074,7 +5074,7 @@ void mbedtls_ssl_buffering_free(mbedtls_ssl_context *ssl)
     ssl_free_buffered_record(ssl);
 
     for (offset = 0; offset < MBEDTLS_SSL_MAX_BUFFERED_HS; offset++) {
-        ssl_buffering_free_slot(ssl, offset);
+        ssl_buffering_free_slot(ssl, (uint8_t) offset);
     }
 }
 
@@ -5104,7 +5104,7 @@ void mbedtls_ssl_write_version(unsigned char version[2], int transport,
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
         tls_version_formatted =
-            ~(tls_version - (tls_version == 0x0302 ? 0x0202 : 0x0201));
+            (uint16_t) (uint16_t) (uint16_t) (uint16_t) ~(tls_version - (tls_version == 0x0302 ? 0x0202 : 0x0201));
     } else
 #else
     ((void) transport);
@@ -5122,7 +5122,7 @@ uint16_t mbedtls_ssl_read_version(const unsigned char version[2],
 #if defined(MBEDTLS_SSL_PROTO_DTLS)
     if (transport == MBEDTLS_SSL_TRANSPORT_DATAGRAM) {
         tls_version =
-            ~(tls_version - (tls_version == 0xfeff ? 0x0202 : 0x0201));
+            (uint16_t) (uint16_t) (uint16_t) (uint16_t) ~(tls_version - (tls_version == 0xfeff ? 0x0202 : 0x0201));
     }
 #else
     ((void) transport);

--- a/src/mbedtls/library/ssl_tls.c
+++ b/src/mbedtls/library/ssl_tls.c
@@ -88,7 +88,7 @@ int mbedtls_ssl_conf_cid(mbedtls_ssl_config *conf,
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
-    conf->ignore_unexpected_cid = ignore_other_cid;
+    conf->ignore_unexpected_cid = (uint8_t) ignore_other_cid;
     conf->cid_len = len;
     return 0;
 }
@@ -102,7 +102,7 @@ int mbedtls_ssl_set_cid(mbedtls_ssl_context *ssl,
         return MBEDTLS_ERR_SSL_BAD_INPUT_DATA;
     }
 
-    ssl->negotiate_cid = enable;
+    ssl->negotiate_cid = (uint8_t) enable;
     if (enable == MBEDTLS_SSL_CID_DISABLED) {
         MBEDTLS_SSL_DEBUG_MSG(3, ("Disable use of CID extension."));
         return 0;
@@ -1206,11 +1206,11 @@ static int ssl_handshake_init(mbedtls_ssl_context *ssl)
                 continue;
             }
 #if defined(MBEDTLS_KEY_EXCHANGE_ECDSA_CERT_REQ_ALLOWED_ENABLED)
-            *p = ((hash << 8) | MBEDTLS_SSL_SIG_ECDSA);
+            *p = (uint16_t) ((hash << 8) | MBEDTLS_SSL_SIG_ECDSA);
             p++;
 #endif
 #if defined(MBEDTLS_RSA_C)
-            *p = ((hash << 8) | MBEDTLS_SSL_SIG_RSA);
+            *p = (uint16_t) ((hash << 8) | MBEDTLS_SSL_SIG_RSA);
             p++;
 #endif
         }
@@ -1536,12 +1536,12 @@ int mbedtls_ssl_session_reset(mbedtls_ssl_context *ssl)
 
 void mbedtls_ssl_conf_endpoint(mbedtls_ssl_config *conf, int endpoint)
 {
-    conf->endpoint   = endpoint;
+    conf->endpoint   = (uint8_t) endpoint;
 }
 
 void mbedtls_ssl_conf_transport(mbedtls_ssl_config *conf, int transport)
 {
-    conf->transport = transport;
+    conf->transport = (uint8_t) transport;
 }
 
 #if defined(MBEDTLS_SSL_DTLS_ANTI_REPLAY)
@@ -1574,7 +1574,7 @@ void mbedtls_ssl_conf_handshake_timeout(mbedtls_ssl_config *conf,
 
 void mbedtls_ssl_conf_authmode(mbedtls_ssl_config *conf, int authmode)
 {
-    conf->authmode   = authmode;
+    conf->authmode   = (uint8_t) authmode;
 }
 
 #if defined(MBEDTLS_X509_CRT_PARSE_C)
@@ -1853,7 +1853,7 @@ void mbedtls_ssl_set_hs_dn_hints(mbedtls_ssl_context *ssl,
 void mbedtls_ssl_set_hs_authmode(mbedtls_ssl_context *ssl,
                                  int authmode)
 {
-    ssl->handshake->sni_authmode = authmode;
+    ssl->handshake->sni_authmode = (uint8_t) authmode;
 }
 #endif
 
@@ -2873,13 +2873,13 @@ int mbedtls_ssl_conf_max_frag_len(mbedtls_ssl_config *conf, unsigned char mfl_co
 
 void mbedtls_ssl_conf_legacy_renegotiation(mbedtls_ssl_config *conf, int allow_legacy)
 {
-    conf->allow_legacy_renegotiation = allow_legacy;
+    conf->allow_legacy_renegotiation = (uint8_t) allow_legacy;
 }
 
 #if defined(MBEDTLS_SSL_RENEGOTIATION)
 void mbedtls_ssl_conf_renegotiation(mbedtls_ssl_config *conf, int renegotiation)
 {
-    conf->disable_renegotiation = renegotiation;
+    conf->disable_renegotiation = (uint8_t) renegotiation;
 }
 
 void mbedtls_ssl_conf_renegotiation_enforced(mbedtls_ssl_config *conf, int max_records)

--- a/src/mbedtls/library/ssl_tls12_server.c
+++ b/src/mbedtls/library/ssl_tls12_server.c
@@ -3791,7 +3791,7 @@ int mbedtls_ssl_handshake_server_step(mbedtls_ssl_context *ssl)
 
 void mbedtls_ssl_conf_preference_order(mbedtls_ssl_config *conf, int order)
 {
-    conf->respect_cli_pref = order;
+    conf->respect_cli_pref = (uint8_t) order;
 }
 
 #endif

--- a/src/mbedtls/library/x509.c
+++ b/src/mbedtls/library/x509.c
@@ -665,7 +665,7 @@ int mbedtls_x509_get_ext(unsigned char **p, const unsigned char *end,
 
 static char nibble_to_hex_digit(int i)
 {
-    return (i < 10) ? (i + '0') : (i - 10 + 'A');
+    return (char) ((i < 10) ? (i + '0') : (i - 10 + 'A'));
 }
 
 int mbedtls_x509_dn_gets(char *buf, size_t size, const mbedtls_x509_name *dn)
@@ -727,7 +727,7 @@ int mbedtls_x509_dn_gets(char *buf, size_t size, const mbedtls_x509_name *dn)
                 return MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
             }
             asn1_len_size = ret;
-            if ((ret = mbedtls_asn1_write_tag(&asn1_len_p, asn1_tag_len_buf, name->val.tag)) < 0) {
+            if ((ret = mbedtls_asn1_write_tag(&asn1_len_p, asn1_tag_len_buf, (unsigned char) name->val.tag)) < 0) {
                 return MBEDTLS_ERR_ERROR_CORRUPTION_DETECTED;
             }
             asn1_tag_size = ret;

--- a/src/mbedtls/library/x509_create.c
+++ b/src/mbedtls/library/x509_create.c
@@ -145,7 +145,7 @@ static int parse_attribute_value_string(const char *s,
                 if (n == 0) {
                     return MBEDTLS_ERR_X509_INVALID_NAME;
                 }
-                *(d++) = n;
+                *(d++) = (unsigned char) n;
                 c++;
             } else if (c < end && strchr(" ,=+<>#;\"\\", *c)) {
                 *(d++) = *c;
@@ -196,7 +196,7 @@ static int parse_attribute_value_hex_der_encoded(const char *s,
         if (c < 0) {
             goto error;
         }
-        der[i] = c;
+        der[i] = (unsigned char) c;
     }
 
     *tag = der[0];
@@ -340,7 +340,7 @@ int mbedtls_x509_set_extension(mbedtls_asn1_named_data **head, const char *oid, 
         return MBEDTLS_ERR_X509_ALLOC_FAILED;
     }
 
-    cur->val.p[0] = critical;
+    cur->val.p[0] = (unsigned char) critical;
     memcpy(cur->val.p + 1, val, val_len);
 
     return 0;

--- a/src/mbedtls/library/x509write.c
+++ b/src/mbedtls/library/x509write.c
@@ -109,7 +109,7 @@ int mbedtls_x509_write_set_san_common(mbedtls_asn1_named_data **extensions,
                 MBEDTLS_ASN1_CHK_CLEANUP_ADD(single_san_len,
                                              mbedtls_asn1_write_tag(
                                                  &p, buf,
-                                                 MBEDTLS_ASN1_CONTEXT_SPECIFIC | cur->node.type));
+                                                 (unsigned char) (MBEDTLS_ASN1_CONTEXT_SPECIFIC | cur->node.type)));
             }
             break;
             case MBEDTLS_X509_SAN_DIRECTORY_NAME:

--- a/tools/patch_mbedtls.sh
+++ b/tools/patch_mbedtls.sh
@@ -6,49 +6,143 @@
 #   MBEDTLS_DIR defaults to the package's vendored tree (src/mbedtls).
 #   tools/update_mbedtls.sh passes the staging tree instead.
 #
-# Idempotent. Purpose: clear the 'printf' (and latent 'fprintf'/'exit') that R's
-# tools:::check_compiled_code() flags. Mbed TLS's library/platform.c initialises
-# the mbedtls_printf / mbedtls_fprintf / mbedtls_exit function pointers to libc
-# printf / fprintf / exit; those static initialisers are data relocations that
-# import the libc symbols even though nothing calls the pointers (self-test off).
+# Every patch is IDEMPOTENT: running it on already-patched sources is a no-op.
 #
-# Defining the *_MACRO forms (not *_ALT) makes platform.h alias mbedtls_printf
-# et al. to these no-op macros and makes platform.c skip the pointer definitions
-# entirely -- so no libc reference is emitted. (The *_ALT path does NOT help:
-# platform.h still defaults MBEDTLS_PLATFORM_STD_PRINTF to libc printf, which the
-# pointer initialiser then references.) check_config.h permits *_MACRO with
-# MBEDTLS_PLATFORM_C set and no conflicting STD_* / *_ALT. Runtime behaviour is
-# unchanged: the affected call sites are self-test / debug only and not compiled.
+# Sections:
+#   1. Platform config -- clear the 'printf' (and latent 'fprintf'/'exit') that
+#      R's tools:::check_compiled_code() flags. Mbed TLS's library/platform.c
+#      initialises the mbedtls_printf / mbedtls_fprintf / mbedtls_exit function
+#      pointers to libc printf / fprintf / exit; those static initialisers are
+#      data relocations that import the libc symbols even though nothing calls
+#      the pointers (self-test off). Defining the *_MACRO forms (not *_ALT) makes
+#      platform.h alias mbedtls_printf et al. to no-op macros and makes
+#      platform.c skip the pointer definitions entirely -- so no libc reference
+#      is emitted. check_config.h permits *_MACRO with MBEDTLS_PLATFORM_C set and
+#      no conflicting STD_* / *_ALT. Runtime behaviour is unchanged: the affected
+#      call sites are self-test / debug only and not compiled.
+#   2. Compiler-warning fixes -- surgical narrowing casts that make explicit the
+#      implicit narrowings Mbed TLS performs (assignments to small-int struct
+#      members, etc.), so the bundled sources compile cleanly under strict
+#      diagnostics (-Wconversion). The casts are behaviour-neutral.
 
 set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 MBEDTLS_DIR="${1:-$SCRIPT_DIR/../src/mbedtls}"
 CONFIG="$MBEDTLS_DIR/include/mbedtls/mbedtls_config.h"
+LIB="$MBEDTLS_DIR/library"
 
 if [ ! -f "$CONFIG" ]; then
   echo "Error: mbedtls_config.h not found: $CONFIG" >&2
   exit 1
 fi
 
-echo "Patching Mbed TLS platform config ..."
+# Apply an idempotent perl program (whole-file slurp mode) to a library source
+# file given relative to $LIB, reporting whether it changed anything.
+patch_perl() {
+  rel=$1; prog=$2
+  f="$LIB/$rel"
+  if [ ! -f "$f" ]; then echo "  skip (absent): $rel"; return 0; fi
+  cp "$f" "$f.prepatch"
+  perl -0777 -i -pe "$prog" "$f"
+  if cmp -s "$f" "$f.prepatch"; then echo "  unchanged: $rel"; else echo "  patched:   $rel"; fi
+  rm -f "$f.prepatch"
+}
+
+# ---------------------------------------------------------------------------
+echo "1. Platform config (printf/fprintf/exit -> no-op macros) ..."
 if grep -q 'MBEDTLS_PLATFORM_PRINTF_MACRO' "$CONFIG" 2>/dev/null; then
   echo "  already patched: $CONFIG"
-  exit 0
+else
+  awk '
+    { print }
+    /^#define MBEDTLS_PLATFORM_C[ \t]*$/ && !done {
+      print "/* nanonext: alias printf/fprintf/exit to no-op macros so the compiled"
+      print " * shared object imports none of these libc symbols (see tools/patch_mbedtls.sh)."
+      print " * The (void) cast keeps statement-context calls free of -Wunused-value; the"
+      print " * only compiled call site (mbedtls_mpi_write_file, MBEDTLS_FS_IO) ignores the"
+      print " * return value, all others are self-test only. */"
+      print "#define MBEDTLS_PLATFORM_PRINTF_MACRO(...) ((void) 0)"
+      print "#define MBEDTLS_PLATFORM_FPRINTF_MACRO(...) ((void) 0)"
+      print "#define MBEDTLS_PLATFORM_EXIT_MACRO(...) ((void) 0)"
+      done = 1
+    }
+  ' "$CONFIG" > "$CONFIG.tmp" && mv "$CONFIG.tmp" "$CONFIG"
+  echo "  patched: $CONFIG"
 fi
 
-awk '
-  { print }
-  /^#define MBEDTLS_PLATFORM_C[ \t]*$/ && !done {
-    print "/* nanonext: alias printf/fprintf/exit to no-op macros so the compiled"
-    print " * shared object imports none of these libc symbols (see tools/patch_mbedtls.sh)."
-    print " * The (void) cast keeps statement-context calls free of -Wunused-value; the"
-    print " * only compiled call site (mbedtls_mpi_write_file, MBEDTLS_FS_IO) ignores the"
-    print " * return value, all others are self-test only. */"
-    print "#define MBEDTLS_PLATFORM_PRINTF_MACRO(...) ((void) 0)"
-    print "#define MBEDTLS_PLATFORM_FPRINTF_MACRO(...) ((void) 0)"
-    print "#define MBEDTLS_PLATFORM_EXIT_MACRO(...) ((void) 0)"
-    done = 1
-  }
-' "$CONFIG" > "$CONFIG.tmp" && mv "$CONFIG.tmp" "$CONFIG"
-echo "  patched: $CONFIG"
+# ---------------------------------------------------------------------------
+echo "2. Compiler-warning fixes (narrowing casts) ..."
+
+patch_perl aes.c '
+  s/\Q#define XTIME(x) (((x) << 1) ^ (((x) & 0x80) ? 0x1B : 0x00))\E/#define XTIME(x) ((uint8_t) (((x) << 1) ^ (((x) & 0x80) ? 0x1B : 0x00)))/;
+  s/\Qy = (y << 1) | (y >> 7);\E/y = (uint8_t) ((y << 1) | (y >> 7));/g;
+'
+patch_perl asn1parse.c '
+  s/\Q0xFF, tag, 0, 0,\E/0xFF, (unsigned char) tag, 0, 0,/;
+'
+patch_perl asn1write.c '
+  s/\Qmbedtls_asn1_write_len_and_tag(p, start, len, tag)\E/mbedtls_asn1_write_len_and_tag(p, start, len, (unsigned char) tag)/g;
+'
+patch_perl bignum.c '
+  s/\Q#define TO_SIGN(x) ((mbedtls_mpi_sint) (((mbedtls_mpi_uint) x) >> (biL - 1)) * -2 + 1)\E/#define TO_SIGN(x) ((short) ((mbedtls_mpi_sint) (((mbedtls_mpi_uint) x) >> (biL - 1)) * -2 + 1))/;
+  s/\Qmbedtls_ct_mpi_sign_if(do_swap, s, Y->s)\E/mbedtls_ct_mpi_sign_if(do_swap, (short) s, Y->s)/;
+  s/\QX->s = cmp == 0 ? 1 : s;\E/X->s = (short) (cmp == 0 ? 1 : s);/;
+  s/\QX->s = -s;\E/X->s = (short) -s;/;
+  s/\QX->s = s;\E/X->s = (short) s;/;
+'
+patch_perl ccm.c '
+  s/\Qctx->ctr[0] = ctx->q - 1;\E/ctx->ctr[0] = (unsigned char) (ctx->q - 1);/;
+'
+patch_perl constant_time.c '
+  s/\Qbuf[n] = mbedtls_ct_uint_if(no_op, current, next);\E/buf[n] = (unsigned char) mbedtls_ct_uint_if(no_op, current, next);/;
+  s/\Qbuf[total-1] = mbedtls_ct_uint_if_else_0(no_op, buf[total-1]);\E/buf[total-1] = (unsigned char) mbedtls_ct_uint_if_else_0(no_op, buf[total-1]);/;
+'
+patch_perl ctr_drbg.c '
+  s/\Qkey[i] = i;\E/key[i] = (unsigned char) i;/;
+'
+patch_perl ecp.c '
+  s/\Qbuf[0] = 0x02 + mbedtls_mpi_get_bit(&P->Y, 0);\E/buf[0] = (unsigned char) (0x02 + mbedtls_mpi_get_bit(&P->Y, 0));/;
+  s/\QT_size = 1U << (w - 1);\E/T_size = (unsigned char) (1U << (w - 1));/g;
+  s{\Qi = 1U << (j / d);\E}{i = (unsigned char) (1U << (j / d));};
+  s/\Qb = mbedtls_mpi_get_bit(m, i);\E/b = (unsigned char) mbedtls_mpi_get_bit(m, i);/;
+'
+patch_perl gcm.c '
+  s/\Qctx->mode = mode;\E/ctx->mode = (unsigned char) mode;/;
+'
+patch_perl ssl_msg.c '
+  s/\Qmsg->type = ssl->out_msgtype;\E/msg->type = (unsigned char) ssl->out_msgtype;/;
+  s/\Qrec.type = ssl->out_msgtype;\E/rec.type = (uint8_t) ssl->out_msgtype;/;
+  s/\Qssl_buffering_free_slot(ssl, offset);\E/ssl_buffering_free_slot(ssl, (uint8_t) offset);/;
+  s/\Q~(tls_version - (tls_version == 0x0302 ? 0x0202 : 0x0201));\E/(uint16_t) ~(tls_version - (tls_version == 0x0302 ? 0x0202 : 0x0201));/;
+  s/\Q~(tls_version - (tls_version == 0xfeff ? 0x0202 : 0x0201));\E/(uint16_t) ~(tls_version - (tls_version == 0xfeff ? 0x0202 : 0x0201));/;
+'
+patch_perl ssl_tls.c '
+  s/\Qconf->ignore_unexpected_cid = ignore_other_cid;\E/conf->ignore_unexpected_cid = (uint8_t) ignore_other_cid;/;
+  s/\Qssl->negotiate_cid = enable;\E/ssl->negotiate_cid = (uint8_t) enable;/;
+  s/\Q*p = ((hash << 8) | MBEDTLS_SSL_SIG_ECDSA);\E/*p = (uint16_t) ((hash << 8) | MBEDTLS_SSL_SIG_ECDSA);/;
+  s/\Q*p = ((hash << 8) | MBEDTLS_SSL_SIG_RSA);\E/*p = (uint16_t) ((hash << 8) | MBEDTLS_SSL_SIG_RSA);/;
+  s/\Qconf->endpoint   = endpoint;\E/conf->endpoint   = (uint8_t) endpoint;/;
+  s/\Qconf->transport = transport;\E/conf->transport = (uint8_t) transport;/;
+  s/\Qconf->authmode   = authmode;\E/conf->authmode   = (uint8_t) authmode;/;
+  s/\Qssl->handshake->sni_authmode = authmode;\E/ssl->handshake->sni_authmode = (uint8_t) authmode;/;
+  s/\Qconf->allow_legacy_renegotiation = allow_legacy;\E/conf->allow_legacy_renegotiation = (uint8_t) allow_legacy;/;
+  s/\Qconf->disable_renegotiation = renegotiation;\E/conf->disable_renegotiation = (uint8_t) renegotiation;/;
+'
+patch_perl ssl_tls12_server.c '
+  s/\Qconf->respect_cli_pref = order;\E/conf->respect_cli_pref = (uint8_t) order;/;
+'
+patch_perl x509.c '
+  s/\Qreturn (i < 10) ? (i + '\''0'\'') : (i - 10 + '\''A'\'');\E/return (char) ((i < 10) ? (i + '\''0'\'') : (i - 10 + '\''A'\''));/;
+  s/\Qmbedtls_asn1_write_tag(&asn1_len_p, asn1_tag_len_buf, name->val.tag)\E/mbedtls_asn1_write_tag(&asn1_len_p, asn1_tag_len_buf, (unsigned char) name->val.tag)/;
+'
+patch_perl x509_create.c '
+  s/\Q*(d++) = n;\E/*(d++) = (unsigned char) n;/;
+  s/\Qder[i] = c;\E/der[i] = (unsigned char) c;/;
+  s/\Qcur->val.p[0] = critical;\E/cur->val.p[0] = (unsigned char) critical;/;
+'
+patch_perl x509write.c '
+  s/\QMBEDTLS_ASN1_CONTEXT_SPECIFIC | cur->node.type));\E/(unsigned char) (MBEDTLS_ASN1_CONTEXT_SPECIFIC | cur->node.type)));/;
+'
+
+echo "=== patch_mbedtls.sh complete ==="


### PR DESCRIPTION
Makes the implicit integer narrowings in the vendored Mbed TLS sources explicit (replayed via `tools/patch_mbedtls.sh`) so they compile cleanly under `-Wconversion`; the casts are behaviour-neutral — every patched object compiles byte-identical to before.