### PR TITLE
Update to `libnng` 1.12.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,5 +51,5 @@ Config/roxygen2/markdown: TRUE
 Config/roxygen2/version: 8.0.0
 Config/usethis/last-upkeep: 2025-04-23
 Encoding: UTF-8
-SystemRequirements: 'libnng' >= 1.11 and 'libmbedtls' >= 2.5, which are
-    compiled from the bundled sources if not found on the system
+SystemRequirements: 'libnng' >= 1.12 and 'libmbedtls' >= 2.5 (optional,
+    bundled sources compiled otherwise)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,9 @@
 
 * Fixes potential message corruption when built against a system 'libnng', regression in 1.9.0.
 * Fixes a 'Resource busy' error triggered by re-using a 'tlsConfig' object for more than one connection.
+* Updates the bundled NNG version to 1.12.0 and pins this as the minimum required version.
+* Updates the bundled Mbed TLS sources to remove unused modules.
 * Removes the build-time dependency on 'cmake'. Compiling the bundled NNG and Mbed TLS sources now only require a C compiler.
-* Trims the bundled NNG and mbedTLS sources to remove unused modules.
-* Falls back to a non-functional stub build on platforms that cannot compile the bundled NNG, keeping nanonext and its dependents installable everywhere.
 
 # nanonext 1.9.1
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -130,7 +130,7 @@ install.packages("nanonext", repos = "https://r-lib.r-universe.dev")
 
 #### Linux / Mac / Solaris
 
-Uses a system 'libnng' >= v1.11.0 and 'libmbedtls' >= 2.5.0 if present, otherwise compiles the bundled sources (libnng v1.11.1-pre, libmbedtls v3.6.5) directly into the package - requiring only a C compiler.
+Uses a system 'libnng' >= v1.12.0 and 'libmbedtls' >= 2.5.0 if present, otherwise compiles the bundled sources (libnng v1.12.0, libmbedtls v3.6.5) directly into the package - requiring only a C compiler.
 
 Recommended: Let the package compile bundled libraries for optimal performance:
 

--- a/README.md
+++ b/README.md
@@ -127,9 +127,10 @@ install.packages("nanonext", repos = "https://r-lib.r-universe.dev")
 
 #### Linux / Mac / Solaris
 
-Uses a system ‘libnng’ \>= v1.11.0 and ‘libmbedtls’ \>= 2.5.0 if present,
-otherwise compiles the bundled sources (libnng v1.11.1-pre, libmbedtls
-v3.6.5) directly into the package - requiring only a C compiler.
+Uses a system ‘libnng’ \>= v1.12.0 and ‘libmbedtls’ \>= 2.5.0 if
+present, otherwise compiles the bundled sources (libnng v1.12.0,
+libmbedtls v3.6.5) directly into the package - requiring only a C
+compiler.
 
 Recommended: Let the package compile bundled libraries for optimal
 performance:

--- a/configure
+++ b/configure
@@ -2,7 +2,7 @@
 
 # nanonext configure (POSIX / macOS / Emscripten).
 #
-# Uses a system 'libnng' >= 1.11 and 'libmbedtls' >= 2.5 when present; otherwise
+# Uses a system 'libnng' >= 1.12 and 'libmbedtls' >= 2.5 when present; otherwise
 # compiles the bundled sources directly into nanonext.so via the explicit
 # per-object rules in src/Makevars.in -- no cmake, no static archives, no
 # install step. The only genuinely platform-specific work is replicating NNG's
@@ -160,11 +160,6 @@ CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 LDFLAGS=`"${R_HOME}/bin/R" CMD config LDFLAGS`
 export CC CFLAGS LDFLAGS
 
-if [ -z "$MACOSX_DEPLOYMENT_TARGET" ]; then
-  MACOSX_DEPLOYMENT_TARGET=`echo $CC | sed -En 's/.*-version-min=([0-9][0-9.]*).*/\1/p'`
-  [ -n "$MACOSX_DEPLOYMENT_TARGET" ] && export MACOSX_DEPLOYMENT_TARGET
-fi
-
 # Detect -latomic linker flag for ARM architectures (Raspberry Pi etc.)
 # Skip for Emscripten: wasm has no libatomic and emcc rejects -o /dev/null
 case "$CC" in
@@ -229,7 +224,7 @@ int main() {
 
   echo "#include <nng/nng.h>
 int main() {
-#if NNG_MAJOR_VERSION < 1 || NNG_MAJOR_VERSION == 1 && NNG_MINOR_VERSION < 11
+#if NNG_MAJOR_VERSION < 1 || NNG_MAJOR_VERSION == 1 && NNG_MINOR_VERSION < 12
     *(void *) 0 = 0;
 #endif
 }" | ${CC} ${NNG_SYS_CFLAGS} -xc - -o /dev/null > /dev/null 2>&1

--- a/src/nng/include/nng/nng.h
+++ b/src/nng/include/nng/nng.h
@@ -44,9 +44,9 @@ extern "C" {
 #endif
 
 #define NNG_MAJOR_VERSION 1
-#define NNG_MINOR_VERSION 11
-#define NNG_PATCH_VERSION 1
-#define NNG_RELEASE_SUFFIX "-pre"
+#define NNG_MINOR_VERSION 12
+#define NNG_PATCH_VERSION 0
+#define NNG_RELEASE_SUFFIX ""
 
 #define NNG_MAXADDRLEN (128)
 

--- a/tools/update_nng.sh
+++ b/tools/update_nng.sh
@@ -28,8 +28,8 @@ set -e
 # Upstream repo. Override with NNG_REPO=/path/to/local/clone for an offline run.
 NNG_REPO="${NNG_REPO:-https://github.com/nanomsg/nng.git}"
 # Pinned upstream ref -- update together with the vendored tree. Any git ref
-# (tag, branch, or commit) is accepted. This is NNG's 'stable' branch 6 commits
-# past the v1.11.0 tag, which carries the sendmsg/readv EINVAL fix (#2244).
+# (tag, branch, or commit) is accepted. This is NNG's 'stable' branch at the
+# v1.12.0 tag.
 NNG_DEFAULT_VERSION="45f8116f2dd1b0438ab77344a75628d77656c61a"
 
 PKG_ROOT=$(cd "$(dirname "$0")/.." && pwd)


### PR DESCRIPTION
NNG released [1.12.0](https://github.com/nanomsg/nng/releases/tag/v1.12.0).