### PR TITLE
Use non-deprecated Mbed TLS version interface and require Mbed TLS >= 3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Rscript dev/vignettes/precompile.R
 
 ### Compilation
 
-The `configure` script detects a system `libmbedtls` (>= 2.5.0) and `libnng` (>= 1.11.0); if not found, the bundled sources are compiled **directly into `nanonext.so`** via explicit per-object rules in `src/Makevars` (no cmake, no static archives, no install step). To force compilation of the bundled libraries: `Sys.setenv(NANONEXT_LIBS = 1)`.
+The `configure` script detects a system `libmbedtls` (>= 3.0.0) and `libnng` (>= 1.12.0); if not found, the bundled sources are compiled **directly into `nanonext.so`** via explicit per-object rules in `src/Makevars` (no cmake, no static archives, no install step). To force compilation of the bundled libraries: `Sys.setenv(NANONEXT_LIBS = 1)`.
 
 `configure` ports NNG's POSIX feature probes to portable shell (setting the `NNG_HAVE_*` macros and selecting the poller / random-source variant), then substitutes the include flags, defines, link flags and bundled object lists into `src/Makevars.in`. Windows uses fully static `src/Makevars.win` / `src/Makevars.ucrt` (no configure step). All three Makevars are **generated artifacts** ("do not edit by hand") produced by `tools/generate_makevars.sh` from the `tools/*.list` source lists — the single source of truth. See `## Build System` below.
 
@@ -79,7 +79,7 @@ Key files:
 ### External Dependencies
 
 Bundled in source:
-- `libnng` v1.11.0 (messaging library) - in `src/nng/`
+- `libnng` v1.12.0 (messaging library) - in `src/nng/`
 - `libmbedtls` v3.6.5 (TLS implementation) - in `src/mbedtls/`
 
 ### Thread-to-R Callback Pattern

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,5 +51,5 @@ Config/roxygen2/markdown: TRUE
 Config/roxygen2/version: 8.0.0
 Config/usethis/last-upkeep: 2025-04-23
 Encoding: UTF-8
-SystemRequirements: 'libnng' >= 1.12 and 'libmbedtls' >= 2.5 (optional,
+SystemRequirements: 'libnng' >= 1.12 and 'libmbedtls' >= 3.0 (optional,
     bundled sources compiled otherwise)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,8 +4,8 @@
 
 * Fixes potential message corruption when built against a system 'libnng', regression in 1.9.0.
 * Fixes a 'Resource busy' error triggered by re-using a 'tlsConfig' object for more than one connection.
-* Updates the bundled NNG version to 1.12.0 and pins this as the minimum required version.
-* Updates the bundled Mbed TLS sources to remove unused modules.
+* Updates the bundled NNG version to 1.12.0, and the bundled Mbed TLS sources to remove unused modules.
+* Increases the minimum supported system `libnng` version to >= 1.12.0, and 'libmbedtls' version to >= 3.0.
 * Removes the build-time dependency on 'cmake'. Compiling the bundled NNG and Mbed TLS sources now only require a C compiler.
 
 # nanonext 1.9.1

--- a/README.Rmd
+++ b/README.Rmd
@@ -130,7 +130,7 @@ install.packages("nanonext", repos = "https://r-lib.r-universe.dev")
 
 #### Linux / Mac / Solaris
 
-Uses a system 'libnng' >= v1.12.0 and 'libmbedtls' >= 2.5.0 if present, otherwise compiles the bundled sources (libnng v1.12.0, libmbedtls v3.6.5) directly into the package - requiring only a C compiler.
+Uses a system 'libnng' >= v1.12.0 and 'libmbedtls' >= v3.0.0 if present, otherwise compiles the bundled sources (libnng v1.12.0, libmbedtls v3.6.5) directly into the package - requiring only a C compiler.
 
 Recommended: Let the package compile bundled libraries for optimal performance:
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ install.packages("nanonext", repos = "https://r-lib.r-universe.dev")
 
 #### Linux / Mac / Solaris
 
-Uses a system ‘libnng’ \>= v1.12.0 and ‘libmbedtls’ \>= 2.5.0 if
+Uses a system ‘libnng’ \>= v1.12.0 and ‘libmbedtls’ \>= v3.0.0 if
 present, otherwise compiles the bundled sources (libnng v1.12.0,
 libmbedtls v3.6.5) directly into the package - requiring only a C
 compiler.

--- a/configure
+++ b/configure
@@ -2,7 +2,7 @@
 
 # nanonext configure (POSIX / macOS / Emscripten).
 #
-# Uses a system 'libnng' >= 1.12 and 'libmbedtls' >= 2.5 when present; otherwise
+# Uses a system 'libnng' >= 1.12 and 'libmbedtls' >= 3.0 when present; otherwise
 # compiles the bundled sources directly into nanonext.so via the explicit
 # per-object rules in src/Makevars.in -- no cmake, no static archives, no
 # install step. The only genuinely platform-specific work is replicating NNG's
@@ -207,7 +207,7 @@ else
 
   echo "#include <mbedtls/version.h>
 int main() {
-#if MBEDTLS_VERSION_MAJOR < 2 || MBEDTLS_VERSION_MAJOR == 2 && MBEDTLS_VERSION_MINOR < 5
+#if MBEDTLS_VERSION_MAJOR < 3
     *(void *) 0 = 0;
 #endif
 }" | ${CC} ${MBEDTLS_SYS_CFLAGS} -xc - -o /dev/null > /dev/null 2>&1

--- a/src/mbedtls/include/mbedtls/ssl.h
+++ b/src/mbedtls/include/mbedtls/ssl.h
@@ -1681,8 +1681,11 @@ void mbedtls_ssl_get_dtls_srtp_negotiation_result(const mbedtls_ssl_context *ssl
                                                   mbedtls_dtls_srtp_info *dtls_srtp_info);
 #endif
 
-void mbedtls_ssl_conf_max_version(mbedtls_ssl_config *conf, int major,
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+
+void MBEDTLS_DEPRECATED mbedtls_ssl_conf_max_version(mbedtls_ssl_config *conf, int major,
                                                      int minor);
+#endif
 
 static inline void mbedtls_ssl_conf_max_tls_version(mbedtls_ssl_config *conf,
                                                     mbedtls_ssl_protocol_version tls_version)
@@ -1690,8 +1693,11 @@ static inline void mbedtls_ssl_conf_max_tls_version(mbedtls_ssl_config *conf,
     conf->MBEDTLS_PRIVATE(max_tls_version) = tls_version;
 }
 
-void mbedtls_ssl_conf_min_version(mbedtls_ssl_config *conf, int major,
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+
+void MBEDTLS_DEPRECATED mbedtls_ssl_conf_min_version(mbedtls_ssl_config *conf, int major,
                                                      int minor);
+#endif
 
 static inline void mbedtls_ssl_conf_min_tls_version(mbedtls_ssl_config *conf,
                                                     mbedtls_ssl_protocol_version tls_version)

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -72,9 +72,6 @@ typedef struct nano_handle_s {
 
 #ifdef NANONEXT_TLS
 #include <mbedtls/version.h>
-#if MBEDTLS_VERSION_MAJOR < 3
-#include <mbedtls/config.h>
-#endif
 #include <mbedtls/platform.h>
 #include <mbedtls/pk.h>
 #include <mbedtls/rsa.h>

--- a/src/nng/src/supplemental/tls/mbedtls/tls.c
+++ b/src/nng/src/supplemental/tls/mbedtls/tls.c
@@ -82,8 +82,8 @@ struct nng_tls_engine_config {
 	char              *server_name;
 	mbedtls_x509_crt   ca_certs;
 	mbedtls_x509_crl   crl;
-	int                min_ver;
-	int                max_ver;
+	mbedtls_ssl_protocol_version min_ver;
+	mbedtls_ssl_protocol_version max_ver;
 	nng_tls_mode       mode;
 	nni_list           pairs;
 	nni_list           psks;
@@ -447,17 +447,15 @@ config_init(nng_tls_engine_config *cfg, enum nng_tls_mode mode)
 
 	mbedtls_ssl_conf_authmode(&cfg->cfg_ctx, auth_mode);
 
-	cfg->min_ver = MBEDTLS_SSL_MINOR_VERSION_3;
+	cfg->min_ver = MBEDTLS_SSL_VERSION_TLS1_2;
 #ifdef MBEDTLS_SSL_PROTO_TLS1_3
-	cfg->max_ver = MBEDTLS_SSL_MINOR_VERSION_4;
+	cfg->max_ver = MBEDTLS_SSL_VERSION_TLS1_3;
 #else
-	cfg->max_ver = MBEDTLS_SSL_MINOR_VERSION_3;
+	cfg->max_ver = MBEDTLS_SSL_VERSION_TLS1_2;
 #endif
 
-	mbedtls_ssl_conf_min_version(
-	    &cfg->cfg_ctx, MBEDTLS_SSL_MAJOR_VERSION_3, cfg->min_ver);
-	mbedtls_ssl_conf_max_version(
-	    &cfg->cfg_ctx, MBEDTLS_SSL_MAJOR_VERSION_3, cfg->max_ver);
+	mbedtls_ssl_conf_min_tls_version(&cfg->cfg_ctx, cfg->min_ver);
+	mbedtls_ssl_conf_max_tls_version(&cfg->cfg_ctx, cfg->max_ver);
 
 	mbedtls_ssl_conf_rng(&cfg->cfg_ctx, tls_random, cfg);
 	mbedtls_ssl_conf_dbg(&cfg->cfg_ctx, tls_dbg, cfg);
@@ -617,12 +615,12 @@ config_own_cert(nng_tls_engine_config *cfg, const char *cert, const char *key,
 
 	pem = (const uint8_t *) key;
 	len = strlen(key) + 1;
-#if MBEDTLS_VERSION_MAJOR < 3
-	rv = mbedtls_pk_parse_key(&p->key, pem, len, (const uint8_t *) pass,
-	    pass != NULL ? strlen(pass) : 0);
-#else
+#if MBEDTLS_VERSION_MAJOR < 4
 	rv = mbedtls_pk_parse_key(&p->key, pem, len, (const uint8_t *) pass,
 	    pass != NULL ? strlen(pass) : 0, tls_random, NULL);
+#else
+	rv = mbedtls_pk_parse_key(&p->key, pem, len, (const uint8_t *) pass,
+	    pass != NULL ? strlen(pass) : 0);
 #endif
 	if (rv != 0) {
 		tls_log_err("NNG-TLS-KEY", "Failure parsing private key", rv);
@@ -652,8 +650,7 @@ static int
 config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
     nng_tls_version max_ver)
 {
-	int v1, v2;
-	int maj = MBEDTLS_SSL_MAJOR_VERSION_3;
+	mbedtls_ssl_protocol_version v1, v2;
 
 	if (min_ver > max_ver) {
 		nng_log_err("TLS-CFG-VER",
@@ -661,24 +658,12 @@ config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
 		return (NNG_ENOTSUP);
 	}
 	switch (min_ver) {
-#ifdef MBEDTLS_SSL_MINOR_VERSION_1
-	case NNG_TLS_1_0:
-		v1 = MBEDTLS_SSL_MINOR_VERSION_1;
-		break;
-#endif
-#ifdef MBEDTLS_SSL_MINOR_VERSION_2
-	case NNG_TLS_1_1:
-		v1 = MBEDTLS_SSL_MINOR_VERSION_2;
-		break;
-#endif
-#ifdef MBEDTLS_SSL_MINOR_VERSION_3
 	case NNG_TLS_1_2:
-		v1 = MBEDTLS_SSL_MINOR_VERSION_3;
+		v1 = MBEDTLS_SSL_VERSION_TLS1_2;
 		break;
-#endif
 #ifdef MBEDTLS_SSL_PROTO_TLS1_3
 	case NNG_TLS_1_3:
-		v1 = MBEDTLS_SSL_MINOR_VERSION_4;
+		v1 = MBEDTLS_SSL_VERSION_TLS1_3;
 		break;
 #endif
 	default:
@@ -688,26 +673,14 @@ config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
 	}
 
 	switch (max_ver) {
-#ifdef MBEDTLS_SSL_MINOR_VERSION_1
-	case NNG_TLS_1_0:
-		v2 = MBEDTLS_SSL_MINOR_VERSION_1;
-		break;
-#endif
-#ifdef MBEDTLS_SSL_MINOR_VERSION_2
-	case NNG_TLS_1_1:
-		v2 = MBEDTLS_SSL_MINOR_VERSION_2;
-		break;
-#endif
-#ifdef MBEDTLS_SSL_MINOR_VERSION_3
 	case NNG_TLS_1_2:
-		v2 = MBEDTLS_SSL_MINOR_VERSION_3;
+		v2 = MBEDTLS_SSL_VERSION_TLS1_2;
 		break;
-#endif
 	case NNG_TLS_1_3:
 #ifdef MBEDTLS_SSL_PROTO_TLS1_3
-		v2 = MBEDTLS_SSL_MINOR_VERSION_4;
+		v2 = MBEDTLS_SSL_VERSION_TLS1_3;
 #else
-		v2 = MBEDTLS_SSL_MINOR_VERSION_3;
+		v2 = MBEDTLS_SSL_VERSION_TLS1_2;
 #endif
 		break;
 	default:
@@ -718,8 +691,8 @@ config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
 
 	cfg->min_ver = v1;
 	cfg->max_ver = v2;
-	mbedtls_ssl_conf_min_version(&cfg->cfg_ctx, maj, cfg->min_ver);
-	mbedtls_ssl_conf_max_version(&cfg->cfg_ctx, maj, cfg->max_ver);
+	mbedtls_ssl_conf_min_tls_version(&cfg->cfg_ctx, cfg->min_ver);
+	mbedtls_ssl_conf_max_tls_version(&cfg->cfg_ctx, cfg->max_ver);
 	return (0);
 }
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -185,7 +185,7 @@ SEXP rnng_write_cert(SEXP cn, SEXP valid) {
 #else
       (xc = mbedtls_mpi_read_string(&serial, 10, serialvalue)) ||
 #endif
-#if MBEDTLS_VERSION_MAJOR >= 3
+#if MBEDTLS_VERSION_MAJOR < 4
       (xc = mbedtls_pk_parse_key(&loaded_issuer_key, key_buf, klen + 1, NULL, 0, mbedtls_ctr_drbg_random, &ctr_drbg)))
 #else
       (xc = mbedtls_pk_parse_key(&loaded_issuer_key, key_buf, klen + 1, NULL, 0)))
@@ -234,7 +234,7 @@ SEXP rnng_write_cert(SEXP cn, SEXP valid) {
   mbedtls_x509_crt_free(&issuer_crt);
   mbedtls_x509write_crt_free(&crt);
   mbedtls_pk_free(&loaded_issuer_key);
-#if MBEDTLS_VERSION_MAJOR == 3 && MBEDTLS_VERSION_MINOR < 4 || MBEDTLS_VERSION_MAJOR < 3
+#if MBEDTLS_VERSION_MAJOR == 3 && MBEDTLS_VERSION_MINOR < 4
   mbedtls_mpi_free(&serial);
 #endif
   mbedtls_pk_free(&key);

--- a/tools/patch_mbedtls.sh
+++ b/tools/patch_mbedtls.sh
@@ -24,11 +24,6 @@
 #      implicit narrowings Mbed TLS performs (assignments to small-int struct
 #      members, etc.), so the bundled sources compile cleanly under strict
 #      diagnostics (-Wconversion). The casts are behaviour-neutral.
-#   3. Undeprecate in-use API -- drop the MBEDTLS_DEPRECATED_REMOVED guard and the
-#      MBEDTLS_DEPRECATED attribute from mbedtls_ssl_conf_{min,max}_version in
-#      ssl.h. NNG's mbedtls TLS backend still calls both, so leaving them
-#      deprecated emits -Wdeprecated-declarations warnings when NNG is built
-#      against the bundled headers.
 
 set -e
 
@@ -154,11 +149,5 @@ patch_perl x509_create.c '
 patch_perl x509write.c '
   s/\QMBEDTLS_ASN1_CONTEXT_SPECIFIC | cur->node.type));\E/(unsigned char) (MBEDTLS_ASN1_CONTEXT_SPECIFIC | cur->node.type)));/;
 '
-
-# ---------------------------------------------------------------------------
-echo "3. Undeprecate in-use API (mbedtls_ssl_conf_{min,max}_version) ..."
-patch_perl_file "$MBEDTLS_DIR/include/mbedtls/ssl.h" '
-  s/#if !defined\(MBEDTLS_DEPRECATED_REMOVED\)\n\nvoid MBEDTLS_DEPRECATED (mbedtls_ssl_conf_m(?:ax|in)_version\(mbedtls_ssl_config \*conf, int major,\s+int minor\);)\n#endif\n/void $1\n/g;
-' "include/mbedtls/ssl.h"
 
 echo "=== patch_mbedtls.sh complete ==="

--- a/tools/patch_nng.sh
+++ b/tools/patch_nng.sh
@@ -11,14 +11,13 @@
 # re-vendoring a new upstream tag is just: stage upstream -> run this script.
 #
 # Sections:
-#   1. Version bump        -- nanonext ships a "-pre" snapshot of upstream.
-#   2. Compiler-warning fixes -- surgical narrowing / sign-conversion casts and
+#   1. Compiler-warning fixes -- surgical narrowing / sign-conversion casts and
 #      a defensive NULL guard nanonext carries so the bundled sources compile
 #      cleanly under strict diagnostics (-Wconversion / -Wsign-conversion).
-#   3. Diagnostic-pragma removal -- CRAN does not permit compiler
+#   2. Diagnostic-pragma removal -- CRAN does not permit compiler
 #      diagnostic-suppression pragmas (#pragma GCC/clang diagnostic) in compiled
 #      code, so strip them and replay nanonext's portable equivalent.
-#   4. Diagnostics neutering -- route NNG's debug abort/printf/println (the
+#   3. Diagnostics neutering -- route NNG's debug abort/printf/println (the
 #      abort/vprintf/stderr symbols R's tools:::check_compiled_code() flags) to
 #      __builtin_trap() / no-ops. These fire only on internal NNG panics, which
 #      run on background threads where the R API is off-limits, so this is a
@@ -28,7 +27,6 @@ set -e
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 NNG_SRC="${1:-$SCRIPT_DIR/../src/nng/src}"
-NNG_INC="$NNG_SRC/../include"
 
 if [ ! -d "$NNG_SRC" ]; then
   echo "Error: NNG source dir not found: $NNG_SRC" >&2
@@ -48,21 +46,7 @@ patch_perl() {
 }
 
 # ---------------------------------------------------------------------------
-echo "1. Version bump (NNG release suffix -> -pre) ..."
-# nanonext ships a pre-release snapshot a notch above the vendored upstream tag.
-nngh="$NNG_INC/nng/nng.h"
-if [ -f "$nngh" ]; then
-  perl -0777 -i -pe '
-    s/#define NNG_PATCH_VERSION 0\b/#define NNG_PATCH_VERSION 1/;
-    s/#define NNG_RELEASE_SUFFIX ""/#define NNG_RELEASE_SUFFIX "-pre"/;
-  ' "$nngh"
-  echo "  $(grep -E "NNG_PATCH_VERSION|NNG_RELEASE_SUFFIX" "$nngh" | tr "\n" " ")"
-else
-  echo "  skip (absent): include/nng/nng.h"
-fi
-
-# ---------------------------------------------------------------------------
-echo "2. Compiler-warning fixes (narrowing / sign-conversion casts) ..."
+echo "1. Compiler-warning fixes (narrowing / sign-conversion casts) ..."
 
 # POSIX I/O return values (ssize_t) narrowed to int.
 patch_perl platform/posix/posix_udp.c '
@@ -153,8 +137,33 @@ patch_perl platform/windows/win_udp.c '
   s/\bIPV6_MREQ\s+mreq;/struct ipv6_mreq mreq;/;
 '
 
+# mbedtls TLS backend: use the non-deprecated mbedtls_ssl_conf_{min,max}_tls_version
+# API with the mbedtls_ssl_protocol_version enum (MBEDTLS_SSL_VERSION_TLS1_2 / _3),
+# replacing the deprecated major/minor mbedtls_ssl_conf_{min,max}_version forms
+# (-Wdeprecated-declarations). nanonext requires Mbed TLS >= 3 (see configure), where
+# TLS 1.0/1.1 are unsupported and the legacy MBEDTLS_SSL_{MAJOR,MINOR}_VERSION_* macros
+# are gated behind MBEDTLS_DEPRECATED_REMOVED -- so the version handling is rewritten to
+# use the protocol-version enum throughout (config struct fields included), dropping the
+# now-dead 1.0/1.1 switch cases.
+patch_perl supplemental/tls/mbedtls/tls.c '
+  s/\tint +min_ver;\n\tint +max_ver;/\tmbedtls_ssl_protocol_version min_ver;\n\tmbedtls_ssl_protocol_version max_ver;/;
+  s/cfg->min_ver = MBEDTLS_SSL_MINOR_VERSION_3;\n#ifdef MBEDTLS_SSL_PROTO_TLS1_3\n\tcfg->max_ver = MBEDTLS_SSL_MINOR_VERSION_4;\n#else\n\tcfg->max_ver = MBEDTLS_SSL_MINOR_VERSION_3;\n#endif\n\n\tmbedtls_ssl_conf_min_version\(\n\t    &cfg->cfg_ctx, MBEDTLS_SSL_MAJOR_VERSION_3, cfg->min_ver\);\n\tmbedtls_ssl_conf_max_version\(\n\t    &cfg->cfg_ctx, MBEDTLS_SSL_MAJOR_VERSION_3, cfg->max_ver\);/cfg->min_ver = MBEDTLS_SSL_VERSION_TLS1_2;\n#ifdef MBEDTLS_SSL_PROTO_TLS1_3\n\tcfg->max_ver = MBEDTLS_SSL_VERSION_TLS1_3;\n#else\n\tcfg->max_ver = MBEDTLS_SSL_VERSION_TLS1_2;\n#endif\n\n\tmbedtls_ssl_conf_min_tls_version(&cfg->cfg_ctx, cfg->min_ver);\n\tmbedtls_ssl_conf_max_tls_version(&cfg->cfg_ctx, cfg->max_ver);/;
+  s/\tint v1, v2;\n\tint maj = MBEDTLS_SSL_MAJOR_VERSION_3;\n/\tmbedtls_ssl_protocol_version v1, v2;\n/;
+  s/switch \(min_ver\) \{\n#ifdef MBEDTLS_SSL_MINOR_VERSION_1\n\tcase NNG_TLS_1_0:\n\t\tv1 = MBEDTLS_SSL_MINOR_VERSION_1;\n\t\tbreak;\n#endif\n#ifdef MBEDTLS_SSL_MINOR_VERSION_2\n\tcase NNG_TLS_1_1:\n\t\tv1 = MBEDTLS_SSL_MINOR_VERSION_2;\n\t\tbreak;\n#endif\n#ifdef MBEDTLS_SSL_MINOR_VERSION_3\n\tcase NNG_TLS_1_2:\n\t\tv1 = MBEDTLS_SSL_MINOR_VERSION_3;\n\t\tbreak;\n#endif\n#ifdef MBEDTLS_SSL_PROTO_TLS1_3\n\tcase NNG_TLS_1_3:\n\t\tv1 = MBEDTLS_SSL_MINOR_VERSION_4;\n\t\tbreak;\n#endif\n/switch (min_ver) {\n\tcase NNG_TLS_1_2:\n\t\tv1 = MBEDTLS_SSL_VERSION_TLS1_2;\n\t\tbreak;\n#ifdef MBEDTLS_SSL_PROTO_TLS1_3\n\tcase NNG_TLS_1_3:\n\t\tv1 = MBEDTLS_SSL_VERSION_TLS1_3;\n\t\tbreak;\n#endif\n/;
+  s/switch \(max_ver\) \{\n#ifdef MBEDTLS_SSL_MINOR_VERSION_1\n\tcase NNG_TLS_1_0:\n\t\tv2 = MBEDTLS_SSL_MINOR_VERSION_1;\n\t\tbreak;\n#endif\n#ifdef MBEDTLS_SSL_MINOR_VERSION_2\n\tcase NNG_TLS_1_1:\n\t\tv2 = MBEDTLS_SSL_MINOR_VERSION_2;\n\t\tbreak;\n#endif\n#ifdef MBEDTLS_SSL_MINOR_VERSION_3\n\tcase NNG_TLS_1_2:\n\t\tv2 = MBEDTLS_SSL_MINOR_VERSION_3;\n\t\tbreak;\n#endif\n\tcase NNG_TLS_1_3:\n#ifdef MBEDTLS_SSL_PROTO_TLS1_3\n\t\tv2 = MBEDTLS_SSL_MINOR_VERSION_4;\n#else\n\t\tv2 = MBEDTLS_SSL_MINOR_VERSION_3;\n#endif\n\t\tbreak;\n/switch (max_ver) {\n\tcase NNG_TLS_1_2:\n\t\tv2 = MBEDTLS_SSL_VERSION_TLS1_2;\n\t\tbreak;\n\tcase NNG_TLS_1_3:\n#ifdef MBEDTLS_SSL_PROTO_TLS1_3\n\t\tv2 = MBEDTLS_SSL_VERSION_TLS1_3;\n#else\n\t\tv2 = MBEDTLS_SSL_VERSION_TLS1_2;\n#endif\n\t\tbreak;\n/;
+  s/mbedtls_ssl_conf_min_version\(&cfg->cfg_ctx, maj, cfg->min_ver\);\n\tmbedtls_ssl_conf_max_version\(&cfg->cfg_ctx, maj, cfg->max_ver\);/mbedtls_ssl_conf_min_tls_version(&cfg->cfg_ctx, cfg->min_ver);\n\tmbedtls_ssl_conf_max_tls_version(&cfg->cfg_ctx, cfg->max_ver);/;
+'
+
+# mbedtls_pk_parse_key gained f_rng/p_rng parameters in Mbed TLS 3 and dropped them
+# again in Mbed TLS 4. Upstream guards the 2.x form with MBEDTLS_VERSION_MAJOR < 3;
+# nanonext requires >= 3, so retarget the guard to < 4 -- the 3.x (with-RNG) form for
+# 3.x, the parameterless form for 4.x -- keeping the bundled backend buildable on both.
+patch_perl supplemental/tls/mbedtls/tls.c '
+  s/#if MBEDTLS_VERSION_MAJOR < 3\n\trv = mbedtls_pk_parse_key\(&p->key, pem, len, \(const uint8_t \*\) pass,\n\t    pass != NULL \? strlen\(pass\) : 0\);\n#else\n\trv = mbedtls_pk_parse_key\(&p->key, pem, len, \(const uint8_t \*\) pass,\n\t    pass != NULL \? strlen\(pass\) : 0, tls_random, NULL\);\n#endif/#if MBEDTLS_VERSION_MAJOR < 4\n\trv = mbedtls_pk_parse_key(&p->key, pem, len, (const uint8_t *) pass,\n\t    pass != NULL ? strlen(pass) : 0, tls_random, NULL);\n#else\n\trv = mbedtls_pk_parse_key(&p->key, pem, len, (const uint8_t *) pass,\n\t    pass != NULL ? strlen(pass) : 0);\n#endif/;
+'
+
 # ---------------------------------------------------------------------------
-echo "3. Removing compiler diagnostic pragmas (not permitted on CRAN) ..."
+echo "2. Removing compiler diagnostic pragmas (not permitted on CRAN) ..."
 # Strip every #pragma GCC/clang diagnostic line, then replay nanonext's portable
 # substitutes for the warnings those pragmas had suppressed.
 pragma_files=$(grep -rlE '#[[:space:]]*pragma[[:space:]]+(GCC|clang)[[:space:]]+diagnostic' "$NNG_SRC" 2>/dev/null || true)
@@ -173,7 +182,7 @@ patch_perl platform/posix/posix_pipe.c '
 '
 
 # ---------------------------------------------------------------------------
-echo "4. Neutering NNG debug diagnostics (abort / printf / println) ..."
+echo "3. Neutering NNG debug diagnostics (abort / printf / println) ..."
 neuter_debug() {
   f=$1
   [ -f "$f" ] || { echo "  skip (absent): $f"; return 0; }


### PR DESCRIPTION
- Replaces the deprecated `mbedtls_ssl_conf_{min,max}_version` calls in the bundled NNG TLS backend with the `mbedtls_ssl_conf_{min,max}_tls_version` / `mbedtls_ssl_protocol_version` enum interface (config struct fields and version switch included), eliminating `-Wdeprecated-declarations` against both bundled and system Mbed TLS.
- Requires Mbed TLS >= 3 (2.x is end-of-life): `configure` probe, `DESCRIPTION`, both READMEs, `CLAUDE.md`, NEWS.
- Reverts the now-redundant `ssl.h` un-deprecation and removes section 3 of `tools/patch_mbedtls.sh`, restoring pristine vendored Mbed TLS.
- Retargets the `mbedtls_pk_parse_key` guard from `< 3` to `< 4` (bundled NNG backend and our `src/tls.c`): the `f_rng`/`p_rng` parameters exist only in Mbed TLS 3.x, so this keeps both buildable on Mbed TLS 4.
- Removes now-dead Mbed TLS 2.x branches in `src/nanonext.h` and `src/tls.c`.
- Removes the stale version-bump section from `tools/patch_nng.sh`; all NNG-side edits are replayed idempotently there.