### PR TITLE
Fixes R CMD check warning under GCC-Asan + LTO

### DIFF
--- a/src/mbedtls/library/cipher.c
+++ b/src/mbedtls/library/cipher.c
@@ -184,6 +184,9 @@ static inline psa_algorithm_t mbedtls_psa_translate_cipher_mode(
 }
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+__attribute__((noinline, noclone))
+#endif
 void mbedtls_cipher_init(mbedtls_cipher_context_t *ctx)
 {
     memset(ctx, 0, sizeof(mbedtls_cipher_context_t));

--- a/src/mbedtls/library/md.c
+++ b/src/mbedtls/library/md.c
@@ -233,6 +233,9 @@ static int md_can_use_psa(const mbedtls_md_info_t *info)
 }
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+__attribute__((noinline, noclone))
+#endif
 void mbedtls_md_init(mbedtls_md_context_t *ctx)
 {
 

--- a/tools/patch_mbedtls.sh
+++ b/tools/patch_mbedtls.sh
@@ -150,4 +150,20 @@ patch_perl x509write.c '
   s/\QMBEDTLS_ASN1_CONTEXT_SPECIFIC | cur->node.type));\E/(unsigned char) (MBEDTLS_ASN1_CONTEXT_SPECIFIC | cur->node.type)));/;
 '
 
+# ---------------------------------------------------------------------------
+echo "3. GCC LTO false-positive guard (mbedtls_md_init) ..."
+# The CRAN gcc-SAN build (GCC + -flto) reports a -Wstringop-overflow false
+# positive on the memset in mbedtls_md_init: "writing 24 bytes into a region
+# of size 0". Under LTO, GCC's interprocedural analysis propagates a spurious
+# zero object-size from a caller into the memset. noinline/noclone keep a
+# single function body with an opaque pointer parameter, so __builtin_object_size
+# stays unknown and the propagation cannot happen -- rewriting the memset as
+# member assignments does NOT help (it merely relocates the warning to
+# -Warray-bounds). Guarded to real GCC: clang defines __GNUC__ too but has no
+# such false positive and would emit -Wunknown-attributes on noclone. The regex
+# tolerates an already-present block, so re-running is a no-op.
+patch_perl md.c '
+  s/(?:#if defined\(__GNUC__\) && !defined\(__clang__\)\n__attribute__\(\(noinline, noclone\)\)\n#endif\n)?(void mbedtls_md_init\(mbedtls_md_context_t \*ctx\)\n\{)/#if defined(__GNUC__) && !defined(__clang__)\n__attribute__((noinline, noclone))\n#endif\n$1/;
+'
+
 echo "=== patch_mbedtls.sh complete ==="

--- a/tools/patch_mbedtls.sh
+++ b/tools/patch_mbedtls.sh
@@ -151,19 +151,26 @@ patch_perl x509write.c '
 '
 
 # ---------------------------------------------------------------------------
-echo "3. GCC LTO false-positive guard (mbedtls_md_init) ..."
-# The CRAN gcc-SAN build (GCC + -flto) reports a -Wstringop-overflow false
-# positive on the memset in mbedtls_md_init: "writing 24 bytes into a region
-# of size 0". Under LTO, GCC's interprocedural analysis propagates a spurious
-# zero object-size from a caller into the memset. noinline/noclone keep a
-# single function body with an opaque pointer parameter, so __builtin_object_size
-# stays unknown and the propagation cannot happen -- rewriting the memset as
-# member assignments does NOT help (it merely relocates the warning to
-# -Warray-bounds). Guarded to real GCC: clang defines __GNUC__ too but has no
-# such false positive and would emit -Wunknown-attributes on noclone. The regex
-# tolerates an already-present block, so re-running is a no-op.
+echo "3. GCC LTO false-positive guard (context-init memsets) ..."
+# CRAN gcc-SAN (GCC 15 + -flto) reports -Wstringop-overflow false positives on the
+# context-init memsets md.c:239 (24 bytes) and cipher.c:189 (88 bytes): the inlining
+# chain (lto1: "destination object is likely at address zero") roots in
+# ssl_handshake_init, which mbedtls_calloc()s ssl->handshake / ssl->transform_negotiate
+# and returns on NULL, but LTO loses the non-NULL fact for the inlined init memset.
+#
+# The guard must sit on the *leaf* initialisers, not the ssl_tls.c helpers that call
+# them: the helpers have a single caller, so IPA-CP propagates the poisoned pointer
+# into the one body regardless of noinline/noclone. md_init / cipher_init have many
+# callers, so noinline/noclone keeps their parameter opaque (unknown object size) and
+# no caller can trip it. These are the only two reachable leaves (ssl_session_init is
+# not inlined). Rewriting the memset as member stores does NOT help (moves it to
+# -Warray-bounds). Guarded to real GCC -- clang has no such positive and warns
+# -Wunknown-attributes on noclone. The regex tolerates a present block (re-run = no-op).
 patch_perl md.c '
   s/(?:#if defined\(__GNUC__\) && !defined\(__clang__\)\n__attribute__\(\(noinline, noclone\)\)\n#endif\n)?(void mbedtls_md_init\(mbedtls_md_context_t \*ctx\)\n\{)/#if defined(__GNUC__) && !defined(__clang__)\n__attribute__((noinline, noclone))\n#endif\n$1/;
+'
+patch_perl cipher.c '
+  s/(?:#if defined\(__GNUC__\) && !defined\(__clang__\)\n__attribute__\(\(noinline, noclone\)\)\n#endif\n)?(void mbedtls_cipher_init\(mbedtls_cipher_context_t \*ctx\)\n\{)/#if defined(__GNUC__) && !defined(__clang__)\n__attribute__((noinline, noclone))\n#endif\n$1/;
 '
 
 echo "=== patch_mbedtls.sh complete ==="


### PR DESCRIPTION
Fixes #319. For details, see comment in [tools/patch_mbedtls.sh](https://github.com/r-lib/nanonext/compare/fix?expand=1#diff-ebfa45aae16f657ebb81ff8f28474a3d9b633d7a34898bba031bf9de02fb7e39).