### PR TITLE
More efficient `race_aio()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 #### Updates
 
-* `race_aio()` detects aio resolution more efficiently, and no longer misses (or delays detection of) a resolution that races with entry to the function.
+* `race_aio()` is more efficient, and no longer resets the supplied condition variable or consumes its signals.
 
 # nanonext 1.10.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nanonext (development version)
 
+#### Updates
+
+* `race_aio()` detects aio resolution more efficiently, and no longer misses (or delays detection of) a resolution that races with entry to the function.
+
 # nanonext 1.10.1
 
 #### New Features

--- a/src/aio.c
+++ b/src/aio.c
@@ -638,6 +638,24 @@ SEXP rnng_unresolved2(SEXP x) {
 
 }
 
+static R_xlen_t race_scan(SEXP x, const R_xlen_t xlen, R_xlen_t *unresolved) {
+
+  R_xlen_t n = 0;
+  for (R_xlen_t i = 0; i < xlen; i++) {
+    const SEXP elem = VECTOR_PTR_RO(x)[i];
+    if (TYPEOF(elem) != ENVSXP)
+      continue;
+    const SEXP coreaio = nano_findVarInFrame(elem, nano_AioSymbol, NULL);
+    if (NANO_PTR_CHECK(coreaio, nano_AioSymbol) ||
+        ((nano_aio *) NANO_PTR(coreaio))->result)
+      return i + 1;
+    n++;
+  }
+  *unresolved = n;
+  return 0;
+
+}
+
 SEXP rnng_race_aio(SEXP x, SEXP cvar) {
 
   if (TYPEOF(x) != VECSXP)
@@ -647,68 +665,50 @@ SEXP rnng_race_aio(SEXP x, SEXP cvar) {
   if (xlen == 0)
     return Rf_ScalarInteger(0);
 
-  SEXP aios;
-  R_xlen_t live = 0;
-  PROTECT(aios = Rf_allocVector(VECSXP, xlen));
-  for (R_xlen_t i = 0; i < xlen; i++) {
-    const SEXP elem = VECTOR_PTR_RO(x)[i];
-    if (TYPEOF(elem) != ENVSXP)
-      continue;
-    const SEXP coreaio = nano_findVarInFrame(elem, nano_AioSymbol, NULL);
-    if (NANO_PTR_CHECK(coreaio, nano_AioSymbol) ||
-        ((nano_aio *) NANO_PTR(coreaio))->result) {
-      UNPROTECT(1);
-      return Rf_ScalarInteger((int) (i + 1));
-    }
-    SET_VECTOR_ELT(aios, i, coreaio);
-    live++;
-  }
+  R_xlen_t unresolved;
+  R_xlen_t idx = race_scan(x, xlen, &unresolved);
+  if (idx)
+    return Rf_ScalarInteger((int) idx);
 
-  if (live == 0 || NANO_PTR_CHECK(cvar, nano_CvSymbol)) {
-    UNPROTECT(1);
+  if (unresolved == 0 || NANO_PTR_CHECK(cvar, nano_CvSymbol))
     return Rf_ScalarInteger(0);
-  }
 
   nano_cv *ncv = (nano_cv *) NANO_PTR(cvar);
   nng_cv *cv = ncv->cv;
   nng_mtx *mtx = ncv->mtx;
 
+  // observe only: the cv may be shared, e.g. with the dispatcher event loop
+  int snap, flag;
   nng_mtx_lock(mtx);
-  ncv->flag = ncv->flag < 0;
-  ncv->condition = 0;
+  snap = ncv->condition;
+  flag = ncv->flag;
   nng_mtx_unlock(mtx);
 
-  while (1) {
-    for (R_xlen_t i = 0; i < xlen; i++) {
-      const SEXP coreaio = VECTOR_PTR_RO(aios)[i];
-      if (coreaio != R_NilValue && ((nano_aio *) NANO_PTR(coreaio))->result) {
-        UNPROTECT(1);
-        return Rf_ScalarInteger((int) (i + 1));
-      }
-    }
+  while (flag >= 0) {
+
+    idx = race_scan(x, xlen, &unresolved);
+    if (idx)
+      return Rf_ScalarInteger((int) idx);
 
     const nng_time time = nng_clock() + 400;
-    int signalled = 1, flag;
+    int signalled = 1;
     nng_mtx_lock(mtx);
-    while (ncv->condition == 0) {
+    while (ncv->condition == snap && ncv->flag >= 0) {
       if (nng_cv_until(cv, time) == NNG_ETIMEDOUT) {
         signalled = 0;
         break;
       }
     }
-    ncv->condition = 0;
+    snap = ncv->condition;
     flag = ncv->flag;
     nng_mtx_unlock(mtx);
-
-    if (flag < 0) {
-      UNPROTECT(1);
-      return Rf_ScalarInteger(0);
-    }
 
     if (!signalled)
       R_CheckUserInterrupt();
 
   }
+
+  return Rf_ScalarInteger(0);
 
 }
 

--- a/src/aio.c
+++ b/src/aio.c
@@ -638,22 +638,6 @@ SEXP rnng_unresolved2(SEXP x) {
 
 }
 
-static inline R_xlen_t race_find_resolved(SEXP x, R_xlen_t xlen) {
-  for (R_xlen_t i = 0; i < xlen; i++) {
-    SEXP elem = VECTOR_PTR_RO(x)[i];
-    if (TYPEOF(elem) == ENVSXP && !rnng_unresolved2_impl(elem))
-      return i + 1;
-  }
-  return 0;
-}
-
-static inline int race_count_unresolved(SEXP x, R_xlen_t xlen) {
-  int n = 0;
-  for (R_xlen_t i = 0; i < xlen; i++)
-    n += rnng_unresolved2_impl(VECTOR_PTR_RO(x)[i]);
-  return n;
-}
-
 SEXP rnng_race_aio(SEXP x, SEXP cvar) {
 
   if (TYPEOF(x) != VECSXP)
@@ -663,12 +647,27 @@ SEXP rnng_race_aio(SEXP x, SEXP cvar) {
   if (xlen == 0)
     return Rf_ScalarInteger(0);
 
-  R_xlen_t idx = race_find_resolved(x, xlen);
-  if (idx)
-    return Rf_ScalarInteger((int) idx);
+  SEXP aios;
+  R_xlen_t live = 0;
+  PROTECT(aios = Rf_allocVector(VECSXP, xlen));
+  for (R_xlen_t i = 0; i < xlen; i++) {
+    const SEXP elem = VECTOR_PTR_RO(x)[i];
+    if (TYPEOF(elem) != ENVSXP)
+      continue;
+    const SEXP coreaio = nano_findVarInFrame(elem, nano_AioSymbol, NULL);
+    if (NANO_PTR_CHECK(coreaio, nano_AioSymbol) ||
+        ((nano_aio *) NANO_PTR(coreaio))->result) {
+      UNPROTECT(1);
+      return Rf_ScalarInteger((int) (i + 1));
+    }
+    SET_VECTOR_ELT(aios, i, coreaio);
+    live++;
+  }
 
-  if (NANO_PTR_CHECK(cvar, nano_CvSymbol))
+  if (live == 0 || NANO_PTR_CHECK(cvar, nano_CvSymbol)) {
+    UNPROTECT(1);
     return Rf_ScalarInteger(0);
+  }
 
   nano_cv *ncv = (nano_cv *) NANO_PTR(cvar);
   nng_cv *cv = ncv->cv;
@@ -677,17 +676,19 @@ SEXP rnng_race_aio(SEXP x, SEXP cvar) {
   nng_mtx_lock(mtx);
   ncv->flag = ncv->flag < 0;
   ncv->condition = 0;
-  int n = race_count_unresolved(x, xlen);
   nng_mtx_unlock(mtx);
-  if (n == 0)
-    return Rf_ScalarInteger((int) race_find_resolved(x, xlen));
 
-  nng_time time = nng_clock();
-  int current_n, flag;
+  while (1) {
+    for (R_xlen_t i = 0; i < xlen; i++) {
+      const SEXP coreaio = VECTOR_PTR_RO(aios)[i];
+      if (coreaio != R_NilValue && ((nano_aio *) NANO_PTR(coreaio))->result) {
+        UNPROTECT(1);
+        return Rf_ScalarInteger((int) (i + 1));
+      }
+    }
 
-  do {
-    time = time + 400;
-    int signalled = 1;
+    const nng_time time = nng_clock() + 400;
+    int signalled = 1, flag;
     nng_mtx_lock(mtx);
     while (ncv->condition == 0) {
       if (nng_cv_until(cv, time) == NNG_ETIMEDOUT) {
@@ -695,22 +696,19 @@ SEXP rnng_race_aio(SEXP x, SEXP cvar) {
         break;
       }
     }
-    if (signalled)
-      ncv->condition--;
+    ncv->condition = 0;
     flag = ncv->flag;
     nng_mtx_unlock(mtx);
 
-    if (flag < 0)
+    if (flag < 0) {
+      UNPROTECT(1);
       return Rf_ScalarInteger(0);
+    }
 
     if (!signalled)
       R_CheckUserInterrupt();
 
-    current_n = race_count_unresolved(x, xlen);
-
-  } while (current_n == n);
-
-  return Rf_ScalarInteger((int) race_find_resolved(x, xlen));
+  }
 
 }
 


### PR DESCRIPTION
Reworks `race_aio()` to use each aio's completion `result` as the resolution marker — the same one `aio_get_msg()` relies on — rather than polling `nng_aio_busy()` behind repeated environment lookups. This is both cheaper per scan and correctly synchronized with the cv signal, closing windows where a resolution racing with entry to the function could be missed or detected up to 400ms late.

The wait is now also a read-only observer of the condition variable, where previously it reset the cv on entry and consumed signals on wakeup. Those writes could steal a wakeup posted for another waiter on the same cv — with dispatcher, whose event loop waits on this very cv, a stolen signal could leave a task undelivered and hang a subsequent collect. This was the cause of a rare hang observed in the mirai test suite.