### PR TITLE
Include `netinet/in.h` explicitly for `struct sockaddr_in`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 #### Updates
 
 * `race_aio()` is more efficient, and no longer resets the supplied condition variable or consumes its signals.
+* Fixes compilation on FreeBSD (#332).
 
 # nanonext 1.10.1
 

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -60,6 +60,7 @@ typedef struct nano_handle_s {
 #include <ifaddrs.h>
 #include <arpa/inet.h>
 #include <net/if.h>
+#include <netinet/in.h>
 #endif
 #endif
 


### PR DESCRIPTION
Fixes #332.

POSIX says `<arpa/inet.h>` may make the `<netinet/in.h>` symbols visible. This is the case on glibc and macOS, but is not strictly portable.