### PR TITLE
Fix use-after-free in bundled NNG TLS stream cancellation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 #### Updates
 
 * `race_aio()` is more efficient, and no longer resets the supplied condition variable or consumes its signals.
+* Fixes a use-after-free in the bundled 'libnng' when an HTTPS request such as `ncurl()` times out during the TLS handshake (#334).
 * Fixes compilation on FreeBSD (#332).
 
 # nanonext 1.10.1

--- a/R/ncurl.R
+++ b/R/ncurl.R
@@ -57,28 +57,24 @@
 #' @examples
 #' ncurl(
 #'   "https://postman-echo.com/get",
-#'   convert = FALSE,
-#'   response = c("date", "content-type"),
-#'   timeout = 1200L
-#' )
-#' ncurl(
-#'   "https://postman-echo.com/get",
 #'   response = TRUE,
-#'   timeout = 1200L
+#'   timeout = 2000L
 #' )
 #' ncurl(
 #'   "https://postman-echo.com/put",
 #'   method = "PUT",
 #'   headers = c(Authorization = "Bearer APIKEY"),
 #'   data = "hello world",
-#'   timeout = 1500L
+#'   timeout = 2000L
 #' )
 #' ncurl(
 #'   "https://postman-echo.com/post",
+#'   convert = FALSE,
 #'   method = "POST",
 #'   headers = c(`Content-Type` = "application/json"),
 #'   data = '{"key":"value"}',
-#'   timeout = 1500L
+#'   response = c("date", "content-type"),
+#'   timeout = 2000L
 #' )
 #'
 #' @export

--- a/man/ncurl.Rd
+++ b/man/ncurl.Rd
@@ -82,28 +82,24 @@ details.
 \examples{
 ncurl(
   "https://postman-echo.com/get",
-  convert = FALSE,
-  response = c("date", "content-type"),
-  timeout = 1200L
-)
-ncurl(
-  "https://postman-echo.com/get",
   response = TRUE,
-  timeout = 1200L
+  timeout = 2000L
 )
 ncurl(
   "https://postman-echo.com/put",
   method = "PUT",
   headers = c(Authorization = "Bearer APIKEY"),
   data = "hello world",
-  timeout = 1500L
+  timeout = 2000L
 )
 ncurl(
   "https://postman-echo.com/post",
+  convert = FALSE,
   method = "POST",
   headers = c(`Content-Type` = "application/json"),
   data = '{"key":"value"}',
-  timeout = 1500L
+  response = c("date", "content-type"),
+  timeout = 2000L
 )
 
 }

--- a/src/nng/src/supplemental/tls/tls_common.c
+++ b/src/nng/src/supplemental/tls/tls_common.c
@@ -651,7 +651,8 @@ tls_cancel(nni_aio *aio, void *arg, int rv)
 		nni_aio_abort(&conn->tcp_recv, rv);
 	} else if (aio == nni_list_first(&conn->send_queue)) {
 		nni_aio_abort(&conn->tcp_send, rv);
-	} else if (nni_aio_list_active(aio)) {
+	}
+	if (nni_aio_list_active(aio)) {
 		nni_aio_list_remove(aio);
 		nni_aio_finish_error(aio, rv);
 	}

--- a/tools/patch_nng.sh
+++ b/tools/patch_nng.sh
@@ -220,22 +220,19 @@ patch_perl ../include/nng/nng.h '
 # ---------------------------------------------------------------------------
 echo "4. TLS stream cancellation use-after-free fix ..."
 
-# tls_cancel: when the canceled aio is at the head of the send/recv queue,
-# upstream only aborts the underlying tcp_send/tcp_recv aio and leaves the
-# canceled aio queued, relying on the TCP completion callback to fail it via
-# tls_tcp_error(). But nni_aio_abort() on an *idle* aio is a no-op (it sets a
-# deferred a_abort flag that the next nni_aio_begin() clears), and tcp_send is
-# idle whenever nothing is in flight -- e.g. while the TLS handshake awaits
-# the server. The canceled aio then stays queued, iovs intact, while the HTTP
-# layer's cancellation (http_wr_cancel / http_rd_cancel) finishes the caller's
-# aio immediately -- the iovs of the queued aio point into caller-owned
-# buffers (nng_http_req's serialized header block, nng_http_res's body) that
-# the caller is now entitled to free. When the handshake later completes,
-# tls_do_send() hands the freed request buffer to mbedtls_ssl_write(): the
-# use-after-free CRAN's valgrind flagged on an ncurl() HTTPS timeout (the
-# recv path can likewise *write* into a freed response buffer). Fix: always
-# dequeue and finish the canceled aio; keep the abort so any in-flight TCP
-# operation still unwinds.
+# tls_cancel: for the aio at the head of the send/recv queue, upstream only
+# aborts the underlying tcp_send/tcp_recv aio, leaving the canceled aio
+# queued -- but aborting an idle aio is a no-op (nni_aio_abort() just sets a
+# deferred flag that the next nni_aio_begin() clears), and tcp_send is idle
+# while the TLS handshake awaits the server. The stranded aio's iovs point
+# into caller-owned buffers (nng_http_req's serialized headers, the
+# nng_http_res body) that the HTTP layer's cancel (http_wr_cancel /
+# http_rd_cancel) entitles the caller to free at once: when the handshake
+# later completes, tls_do_send() hands a freed buffer to the TLS engine --
+# the use-after-free CRAN's valgrind flagged on an ncurl() HTTPS timeout
+# (the recv path can likewise write into a freed buffer). Fix: always
+# dequeue and finish the canceled aio; the abort is kept so an in-flight
+# TCP operation still unwinds.
 patch_perl supplemental/tls/tls_common.c '
   s/(\} else if \(aio == nni_list_first\(&conn->send_queue\)\) \{\n\t\tnni_aio_abort\(&conn->tcp_send, rv\);\n\t\}) else if \(nni_aio_list_active\(aio\)\) \{/$1\n\tif (nni_aio_list_active(aio)) {/;
 '

--- a/tools/patch_nng.sh
+++ b/tools/patch_nng.sh
@@ -23,6 +23,8 @@
 #      run on background threads where the R API is off-limits, so this is a
 #      no-op in normal use. Also stub the nng/nng.h logging API to static inline
 #      no-ops so every call compiles away and core/log.c can be pruned.
+#   4. Upstream bug fix -- TLS stream cancellation use-after-free (caught by
+#      CRAN's valgrind runs).
 
 set -e
 
@@ -213,6 +215,29 @@ patch_perl ../include/nng/nng.h '
   s/NNG_DECL void nng_log_info\(const char \*msgid, const char \*msg, \.\.\.\);/static inline void nng_log_info(const char *msgid, const char *msg, ...) { (void) msgid; (void) msg; }/;
   s/NNG_DECL void nng_log_debug\(const char \*msgid, const char \*msg, \.\.\.\);/static inline void nng_log_debug(const char *msgid, const char *msg, ...) { (void) msgid; (void) msg; }/;
   s/NNG_DECL void nng_log_auth\(\n    nng_log_level level, const char \*msgid, const char \*msg, \.\.\.\);/static inline void nng_log_auth(nng_log_level level, const char *msgid, const char *msg, ...) { (void) level; (void) msgid; (void) msg; }/;
+'
+
+# ---------------------------------------------------------------------------
+echo "4. TLS stream cancellation use-after-free fix ..."
+
+# tls_cancel: when the canceled aio is at the head of the send/recv queue,
+# upstream only aborts the underlying tcp_send/tcp_recv aio and leaves the
+# canceled aio queued, relying on the TCP completion callback to fail it via
+# tls_tcp_error(). But nni_aio_abort() on an *idle* aio is a no-op (it sets a
+# deferred a_abort flag that the next nni_aio_begin() clears), and tcp_send is
+# idle whenever nothing is in flight -- e.g. while the TLS handshake awaits
+# the server. The canceled aio then stays queued, iovs intact, while the HTTP
+# layer's cancellation (http_wr_cancel / http_rd_cancel) finishes the caller's
+# aio immediately -- the iovs of the queued aio point into caller-owned
+# buffers (nng_http_req's serialized header block, nng_http_res's body) that
+# the caller is now entitled to free. When the handshake later completes,
+# tls_do_send() hands the freed request buffer to mbedtls_ssl_write(): the
+# use-after-free CRAN's valgrind flagged on an ncurl() HTTPS timeout (the
+# recv path can likewise *write* into a freed response buffer). Fix: always
+# dequeue and finish the canceled aio; keep the abort so any in-flight TCP
+# operation still unwinds.
+patch_perl supplemental/tls/tls_common.c '
+  s/(\} else if \(aio == nni_list_first\(&conn->send_queue\)\) \{\n\t\tnni_aio_abort\(&conn->tcp_send, rv\);\n\t\}) else if \(nni_aio_list_active\(aio\)\) \{/$1\n\tif (nni_aio_list_active(aio)) {/;
 '
 
 echo "=== patch_nng.sh complete ==="


### PR DESCRIPTION
Closes #334.

Fixes the use-after-free detected by CRAN's valgrind checks on an ncurl() HTTPS timeout.

When a canceled aio is at the head of the TLS send/recv queue, upstream `tls_cancel` only aborts the underlying TCP aio — a no-op while it is idle (e.g. mid-handshake) — leaving the aio queued with iovs into buffers the HTTP layer has already released to the caller. When the handshake later completes, the freed request buffer is handed to the TLS engine.

This PR's patch (replayed via `tools/patch_nng.sh`) makes `tls_cancel` always dequeue and finish the canceled aio, keeping the abort so an in-flight TCP operation still unwinds.