### PR TITLE
Fix memory leaks in HTTP server teardown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,10 @@
 #### Updates
 
 * `race_aio()` is more efficient, and no longer resets the supplied condition variable or consumes its signals.
+* Fixes memory leaks in `http_server()`: handlers were not freed at server teardown, and HTTP streaming connections never released their request objects (#339).
 * Fixes a rare message leak in the bundled 'libnng' when a socket is closed with an inbound message still in transit (#337).
-* Fixes compilation on FreeBSD (#332).
 * Fixes a use-after-free in the bundled 'libnng' when an HTTPS request such as `ncurl()` times out during the TLS handshake (#334).
+* Fixes compilation on FreeBSD (#332).
 * Removes `monitor()` and `read_monitor()`. Use `pipe_notify()` to be signalled of pipe changes, and `pipe_id()` on a resolved `recvAio` to obtain a pipe ID.
 
 # nanonext 1.10.1

--- a/src/server.c
+++ b/src/server.c
@@ -283,8 +283,10 @@ static void http_server_cleanup(void *arg) {
   nano_http_server *srv = (nano_http_server *) arg;
 
   for (int i = 0; i < srv->handler_count; i++) {
-    if (srv->handlers[i].handler != NULL)
+    if (srv->handlers[i].handler != NULL) {
       nng_http_server_del_handler(srv->server, srv->handlers[i].handler);
+      nng_http_handler_free(srv->handlers[i].handler);
+    }
 
     if (srv->handlers[i].listener != NULL) {
       nng_stream_listener_free(srv->handlers[i].listener);
@@ -303,6 +305,7 @@ static void http_server_cleanup(void *arg) {
         nng_aio_free(ws->recv_aio);
       } else {
         nano_stream_conn *sc = (nano_stream_conn *) conn;
+        nng_http_req_free(sc->req);
         for (int j = 0; j < sc->resp_header_count; j++) {
           free(sc->resp_header_names[j]);
           free(sc->resp_header_values[j]);
@@ -560,6 +563,7 @@ static void conn_cleanup(nano_conn *conn) {
     nng_aio_free(ws->recv_aio);
   } else {
     nano_stream_conn *sc = (nano_stream_conn *) conn;
+    nng_http_req_free(sc->req);
     for (int i = 0; i < sc->resp_header_count; i++) {
       free(sc->resp_header_names[i]);
       free(sc->resp_header_values[i]);
@@ -945,8 +949,10 @@ SEXP rnng_http_server_create(SEXP url, SEXP handlers, SEXP tls) {
     if (srv->tls != NULL)
       nng_tls_config_free(srv->tls);
     for (int i = 0; i < handlers_added; i++) {
-      if (srv->handlers[i].handler != NULL)
+      if (srv->handlers[i].handler != NULL) {
         nng_http_server_del_handler(srv->server, srv->handlers[i].handler);
+        nng_http_handler_free(srv->handlers[i].handler);
+      }
       if (srv->handlers[i].listener != NULL)
         nng_stream_listener_free(srv->handlers[i].listener);
       if (srv->handlers[i].accept_aio != NULL)
@@ -1102,6 +1108,7 @@ static void stream_handler_cb(nng_aio *aio) {
   nano_stream_conn *sc = calloc(1, sizeof(nano_stream_conn));
   if (sc == NULL) {
     nng_http_conn_close(http_conn);
+    nng_http_req_free(req);
     nng_aio_finish(aio, 0);
     return;
   }
@@ -1117,6 +1124,7 @@ static void stream_handler_cb(nng_aio *aio) {
 
   if (nng_aio_alloc(&sc->conn.send_aio, NULL, NULL)) {
     nng_http_conn_close(http_conn);
+    nng_http_req_free(req);
     free(sc);
     nng_aio_finish(aio, 0);
     return;

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -1421,6 +1421,8 @@ if (later && NOT_CRAN) {
   test_zero(stream_srv$close())
 }
 
+if (later) run_event_loop(100L)
+
 test_null(.dispatcher_stop("invalid"))
 test_null(.dispatcher_wait("invalid", 1L))
 test_equal(length(.dispatcher_info("invalid")), 5L)


### PR DESCRIPTION
Fixes #339.

Fixes two ownership bugs in `http_server()`:

1. Handlers were never freed. `http_server_cleanup()` (and the creation failure path) removes each handler from the NNG server with `nng_http_server_del_handler()`, which is a pure list removal that returns ownership to the caller — the matching `nng_http_handler_free()` was missing, so every handler leaked once teardown ran. The removal itself remains necessary, as the handler's data pointer aims into the `srv->handlers` array about to be freed, and the underlying NNG server is port-cached and may outlive the R object. Freeing is safe against in-flight requests since NNG refcounts handlers during dispatch.
2. Streaming requests were never freed. Streaming handlers hijack the connection via `nng_http_hijack()`, which detaches both the connection and the request from NNG's ownership. The request pointer stored in the stream connection was never released. `nng_http_req_free()` is now called wherever the stream connection is destroyed — `conn_cleanup()`, the server cleanup fallback loop, and the two allocation-failure branches after hijacking.

The tests now also process the event loop once after the last HTTP server closes, so its deferred cleanup runs within the test process rather than being abandoned at exit.